### PR TITLE
Make the test suite's pass/fail totals mean something

### DIFF
--- a/rewrite/blade-compiler/Cli.fs
+++ b/rewrite/blade-compiler/Cli.fs
@@ -68,7 +68,11 @@ let printUsage () =
     printfn "  test --mpi                        ... including the MPI decomposition block"
     printfn "                                    (needs mingw msmpi + the MS-MPI runtime)"
     printfn "  test --timing                     ... including the differential timing block (slow)"
-    printfn "                                    (the --omp/--cuda/--timing/--mpi flags combine)"
+    printfn "  test --interp                     ... including the interpreter differential block (slow)"
+    printfn "  test --diff-oracle                ... including the pinned-oracle differential block"
+    printfn "                                    (skips cleanly without ./oracle/Blade.exe)"
+    printfn "                                    (the --omp/--cuda/--timing/--mpi/--interp/"
+    printfn "                                     --diff-oracle flags combine)"
     printfn "  test --ir-only                    Run IR-only tests (fast, no C++ compilation)"
     printfn "  test alloc                        Run C++ allocation-layout tests (contiguity/cardinality)"
     printfn "  test omp-coverage                 Run the OpenMP thread-coverage block standalone"
@@ -801,16 +805,22 @@ let private runFullSuite opts = runAllTestsFullWith [runCliSmokeTests] opts
 
 /// Dispatch the `test` subcommand. `rest` is everything after "test".
 let private dispatchTest (rest: string list) : int =
-    // `--omp` / `--cuda` / `--timing` opt the corresponding blocks into the
-    // full suite; they may appear in any order and combine.
-    let isSuiteFlag f = f = "--omp" || f = "--cuda" || f = "--timing" || f = "--mpi"
+    // `--omp` / `--cuda` / `--timing` / `--mpi` / `--interp` / `--diff-oracle`
+    // opt the corresponding blocks into the full suite; they may appear in any
+    // order and combine. Each has a standalone arm below too; the flag form
+    // exists so an opt-in block still lands in the grand total.
+    let isSuiteFlag f =
+        f = "--omp" || f = "--cuda" || f = "--timing" || f = "--mpi"
+        || f = "--interp" || f = "--diff-oracle"
     match rest with
     | [] -> runFullSuite defaultFullSuiteOptions
     | flags when flags |> List.forall isSuiteFlag ->
         runFullSuite { IncludeOmp = List.contains "--omp" flags
                        IncludeCuda = List.contains "--cuda" flags
                        IncludeTiming = List.contains "--timing" flags
-                       IncludeMpi = List.contains "--mpi" flags }
+                       IncludeMpi = List.contains "--mpi" flags
+                       IncludeInterpDiff = List.contains "--interp" flags
+                       IncludeDiffOracle = List.contains "--diff-oracle" flags }
     | [ "--ir-only" ] -> runAllTests ()
     | [ "--gen" ] -> runAllTestsGenOnly ()
     | [ "normalize" ] ->

--- a/rewrite/blade-compiler/Lowering.fs
+++ b/rewrite/blade-compiler/Lowering.fs
@@ -158,6 +158,36 @@ let emptyTypedEnv () : TypedLowerEnv = {
 let bindTypedVar name id (env: TypedLowerEnv) : TypedLowerEnv =
     { env with Variables = Map.add name id env.Variables }
 
+/// Value expression for destructured sub-binding #i of `binding`.
+///
+/// Positional destructuring reads element i of the tuple (or, for a struct
+/// scrutinee, the field carrying the sub-binding's own name). A CONS binding
+/// differs in exactly one place — its LAST leaf. `let head :: tail = (1, 2, 3)`
+/// binds `tail` to the REMAINDER (2, 3), so that leaf lowers to a re-built
+/// tuple of projections 1.. rather than to projection 1. Emitting a plain
+/// projection there is the miscompile this helper exists to prevent: `tail`
+/// used to come out as the single element 2.
+///
+/// A one-element remainder degrades to the bare element, because Blade has no
+/// 1-tuple — `(x)` is just `x`. TypeCheck's PatCons arm types the leaf by the
+/// identical rule, so the declared type and this value always agree.
+///
+/// `isFlat` only ever applies to positional projections: a cons binding has
+/// fewer leaves than the tuple has slots, so checkDecl's flat-vs-structural
+/// test never selects flat for one, and the remainder must index the scrutinee
+/// structurally in any case.
+let subBindingValue (binding: TypedBinding) (isStruct: bool) (isFlat: bool) (i: int) (name: string) : IRExpr =
+    let baseVar = IRVar (binding.VarId, binding.Type)
+    let isConsBinding = match binding.Destructure with DSConsRest -> true | DSPositional -> false
+    let isRestLeaf = isConsBinding && i = binding.SubBindings.Length - 1
+    if isStruct then IRFieldAccess (baseVar, name)
+    else
+        match binding.Type with
+        | IRTTuple ts when isRestLeaf && ts.Length > i ->
+            let rest = [ for j in i .. ts.Length - 1 -> IRTupleProj (baseVar, j, false) ]
+            if rest.Length = 1 then rest.Head else IRTuple rest
+        | _ -> IRTupleProj (baseVar, i, isFlat)
+
 /// Lower a TypedExpr to IRExpr
 let rec lowerTypedExpr (env: TypedLowerEnv) (texpr: TypedExpr) : IRExpr =
     match texpr.Kind with
@@ -754,9 +784,7 @@ and lowerTypedBlock env (stmts: TypedStmt list) (finalExpr: TypedExpr option) : 
                     binding.SubBindings |> List.mapi (fun i (name, subId, _subTy) -> (i, name, subId))
                 let chained =
                     List.foldBack (fun (i, name, subId) acc ->
-                        let projExpr =
-                            if isStruct then IRFieldAccess (IRVar (binding.VarId, binding.Type), name)
-                            else IRTupleProj (IRVar (binding.VarId, binding.Type), i, isFlat)
+                        let projExpr = subBindingValue binding isStruct isFlat i name
                         IRLet (subId, projExpr, acc)) indexedSubs withChecks
                 IRLet (binding.VarId, value, chained)
         | TStmtAssign (lhs, rhs) ->
@@ -1195,9 +1223,7 @@ let lowerTypedDecl (env: TypedLowerEnv) (decl: TypedDecl) : (Choice<IRFuncDef, I
                 binding.SubBindings.Length = flatCount && binding.SubBindings.Length <> structCount
             | _ -> false
         let subIRBindings = binding.SubBindings |> List.mapi (fun i (name, subId, subTy) ->
-            let projExpr =
-                if isStruct then IRFieldAccess (IRVar (binding.VarId, binding.Type), name)
-                else IRTupleProj (IRVar (binding.VarId, binding.Type), i, isFlat)
+            let projExpr = subBindingValue binding isStruct isFlat i name
             let env' = bindTypedVar name subId env'
             { Id = subId; Name = name; Type = subTy; Value = projExpr; IsConst = true; IsMutable = false })
         let env'' = binding.SubBindings |> List.fold (fun e (name, subId, _) -> bindTypedVar name subId e) env'
@@ -1263,9 +1289,7 @@ let lowerTypedDecl (env: TypedLowerEnv) (decl: TypedDecl) : (Choice<IRFuncDef, I
                           IsConst = true; IsMutable = false }
                     | None ->
                         // Projection fallback — same shape as TDeclLet's branch.
-                        let projExpr =
-                            if isStruct then IRFieldAccess (IRVar (binding.VarId, binding.Type), name)
-                            else IRTupleProj (IRVar (binding.VarId, binding.Type), i, isFlat)
+                        let projExpr = subBindingValue binding isStruct isFlat i name
                         { Id = subId; Name = name; Type = subTy; Value = projExpr
                           IsConst = true; IsMutable = false }
                 (acc @ [bd], bindTypedVar name subId e)

--- a/rewrite/blade-compiler/TypeCheck.fs
+++ b/rewrite/blade-compiler/TypeCheck.fs
@@ -4513,7 +4513,10 @@ and inferBinOp env mode op left right : TypeResult<TypedExpr> =
                         mkExpr sp (ExprLambda ([{ Name = "__bx"; Type = elemAnn }], None, body))))))
                 inferExpr env synth |> Result.map (stampElemUnits env resUnits)
             | _ ->
-            inferArithType mode op tL.Type tR.Type |> Result.map (fun resTy ->
+            // env.Builder: inferArithType mints fresh index-type ids for a
+            // synthesized outer-product result (same allocator deduceOutputType
+            // uses for the method_for output type).
+            inferArithType env.Builder mode op tL.Type tR.Type |> Result.map (fun resTy ->
                 mkTyped (TExprBinOp (mode, op, tL, tR)) resTy)))
 
 /// Checker-level Dist operator dispatch (typed-Dist arc phase 4).
@@ -4722,15 +4725,81 @@ and kernelBodyUnits (env: TypeEnv) (bound: Map<IRId, UnitSig option>) (e: TypedE
     | TExprField _ | TExprTupleIndex _ -> Ok (ofType e.Type)
     | _ -> Ok None
 
-and inferArithType mode op leftTy rightTy : TypeResult<IRType> =
-    // Elementwise boolean/comparison over two ARRAYS lifts to a Bool-element
-    // array of the same shape (mask algebra: `above2 && below5`, `A < B`).
-    // The lowering already synthesizes the object_for with a Bool kernel
-    // (lowerTypedBinOp maps these ops and sets kernelRetType = ETBool), so only
-    // the RESULT TYPE needs to become the array here. Scalars keep scalar Bool;
-    // Outer mode and array<->scalar broadcast are intentionally out of scope for
-    // now and also keep scalar Bool.
-    let elementwiseBoolTy =
+and inferArithType (builder: IRBuilder) mode op leftTy rightTy : TypeResult<IRType> =
+    // Result type for an OUTER (bracketed) op over two arrays, shared by the
+    // comparison/logical branch (`boolResultTy`) and the arithmetic branch
+    // (`bareResult`). Both used to spell this as `mkArrayLike { arrL with ... }`,
+    // which silently smuggled three of the LEFT OPERAND's properties onto a value
+    // that is not the left operand:
+    //
+    //   - Identity. `IRArrayType.Identity` is the handle that says "this type
+    //     describes THAT array". An outer product is a freshly synthesized array
+    //     with no source-level name yet, so it has no identity to claim; wearing
+    //     `arrL`'s makes two genuinely different arrays indistinguishable at the
+    //     type level. `None` is the same answer `deduceOutputType` gives (it
+    //     builds through `mkArrayArrow ... None`) and the same answer the nested-
+    //     array flattener gives when it absorbs an inner array's identity.
+    //
+    //   - IsVirtual. A virtual array (range/reverse) has NO storage — its
+    //     elements are computed from the index. An outer product is materialized:
+    //     codegen's `genObjectForApplication` allocates an `Array<T,2>` and fills
+    //     it from the kernel. So the result is stored even when the left operand
+    //     was virtual; inheriting `true` would have described real storage as
+    //     virtual (and routed the rebuild through `mkVirtualArrayArrow`, whose
+    //     shape gate is meant for index-derived arrays).
+    //
+    //   - Index-type Ids. `IRIndexType.Id` is per-OCCURRENCE identity, minted
+    //     from the builder. Copying operand records verbatim hands the result the
+    //     operands' own ids, so an axis of the product and an axis of an operand
+    //     compare equal by id (the `d.Id = m.Id` shortcut in IR's compound/mask
+    //     prefix check is one consumer; the provider-write dim-name lookup in
+    //     Lowering is another). `deduceOutputType` refreshes ids on every record
+    //     it emits — verbatim copies included — for exactly this reason, and this
+    //     is the same synthesis step, so it follows the same rule.
+    //
+    // Like `deduceOutputType`, the refresh does NOT remap intra-record
+    // back-references (a DepIdx inner extent formula naming its outer record's
+    // id, or a non-empty `Dependencies` list). That is safe here because the
+    // outer-product emitter only ever handles rank-1 plain-dense operands
+    // (`arrA.extents[0]`/`arrB.extents[0]`, a two-deep dense loop), so a
+    // ragged/dependent operand cannot reach this arm at all; if that emitter is
+    // ever generalized, the id refresh must become a substitution.
+    let mkOuterResult (arrL: IRArrayType) (arrR: IRArrayType) (elemTy: IRType) : IRType =
+        mkArrayLike
+            { arrL with
+                ElemType = elemTy
+                IndexTypes =
+                    (arrL.IndexTypes @ arrR.IndexTypes)
+                    |> List.map (fun ix -> { ix with Id = builder.FreshId() })
+                IsVirtual = false
+                Identity = None }
+    // Boolean/comparison ops over ARRAYS lift to a Bool-ELEMENT array; only the
+    // SHAPE rule differs per mode (mask algebra: `above2 && below5`, `A < B`,
+    // `A [<] B`). The lowering already synthesizes the object_for with a Bool
+    // kernel (lowerTypedBinOp maps these ops and sets kernelRetType = ETBool),
+    // so only the RESULT TYPE needs to become the array here.
+    //
+    // Outer mode is the CROSS product of the two operands' index spaces —
+    // `A [<] B` with |A| = 5, |B| = 3 is a 5x3 Bool array, exactly the shape
+    // codegen's deduceOutputType builds (`{A.extents[0], B.extents[0]}`), and
+    // the same concatenation rule the ARITHMETIC Outer branch below already
+    // applies. It used to fall through to the scalar `IRTScalar ETBool` arm,
+    // which was a silent miscompile rather than a missing feature: the loop
+    // nest and the Array<bool,2> allocation were emitted correctly, but the
+    // binding's IR type said "scalar Bool", so genPrintStatements took the
+    // scalar `cout << x` path — and Array's implicit `operator
+    // promote<T,N>::type()` (cpp/nested_array_types.hpp) silently converted the
+    // wrapper to a pointer, printing an ADDRESS. Nothing downstream ever saw
+    // the real values, so the corpus tests passed while emitting garbage.
+    //
+    // Array<->scalar broadcast in Outer mode has no cross axis to build (there
+    // is only one index space), so it still degrades to the scalar Bool arm.
+    //
+    // A FUNCTION, not a value: the Outer-over-two-arrays arm mints fresh index
+    // ids, and an eagerly-bound `let` would burn a pair of them on every
+    // ARITHMETIC binop too (which never reads this), needlessly shifting every
+    // later id — and thus every generated C++ name derived from one.
+    let boolResultTy () =
         match mode, IR.stripUnits leftTy, IR.stripUnits rightTy with
         | Elementwise, ArrayElem arrL, ArrayElem _ ->
             mkArrayLike { arrL with ElemType = IRTScalar ETBool }
@@ -4740,14 +4809,20 @@ and inferArithType mode op leftTy rightTy : TypeResult<IRType> =
         | Elementwise, _, ArrayElem arrR ->
             // scalar <op> array broadcast (`2.0 < A`): result shape follows the array
             mkArrayLike { arrR with ElemType = IRTScalar ETBool }
+        | Outer, ArrayElem arrL, ArrayElem arrR ->
+            // Outer (bracketed) comparison / logical over two arrays: index
+            // spaces concatenate (left axes then right axes), elements are Bool.
+            // Mirrors the arithmetic Outer rule in `bareResult` below, which
+            // keeps the left operand's ElemType instead.
+            mkOuterResult arrL arrR (IRTScalar ETBool)
         | _ -> IRTScalar ETBool
     match op with
     | OpEq | OpNeq | OpLt | OpLe | OpGt | OpGe ->
         // Comparisons require compatible units (unitRulesForOp errors on
         // mismatch; the result carries no annotation)
         unitRulesForOp op (IR.getUnits leftTy) (IR.getUnits rightTy)
-        |> Result.map (fun _ -> elementwiseBoolTy)
-    | OpAnd | OpOr -> Ok elementwiseBoolTy
+        |> Result.map (fun _ -> boolResultTy ())
+    | OpAnd | OpOr -> Ok (boolResultTy ())
     | _ ->
         // Extract unit annotations if present
         let lUnits = IR.getUnits leftTy
@@ -4797,8 +4872,6 @@ and inferArithType mode op leftTy rightTy : TypeResult<IRType> =
             match lBare, rBare with
             | IRTIdxTagged (_, IRefNamed ln), IRTIdxTagged (_, IRefNamed rn) when ln <> rn ->
                 Some (CrossNominalIndexArith (ln, rn))
-            | IRTIdxTagged (_, IRefNamed ln), IRTIdxTagged (_, IRefNamed rn) when ln <> rn ->
-                Some (CrossNominalIndexArith (ln, rn))
             | IRTIdxTagged (_, IRefAnon (lid, _)), IRTIdxTagged (_, IRefAnon (rid, _)) when lid <> rid ->
                 Some (CrossAnonIndexArith (lid, rid))
             | l, r when isIndexType l || isIndexType r ->
@@ -4844,7 +4917,11 @@ and inferArithType mode op leftTy rightTy : TypeResult<IRType> =
             | Outer ->
                 match lBare, rBare with
                 | ArrayElem arrL, ArrayElem arrR ->
-                    mkArrayLike { arrL with IndexTypes = arrL.IndexTypes @ arrR.IndexTypes }
+                    // Element type stays the LEFT operand's (the historical
+                    // arithmetic-Outer convention, matched by lowering's
+                    // kernelRetType = IRTScalar elemTypeL); everything else about
+                    // the result is synthesized fresh — see mkOuterResult.
+                    mkOuterResult arrL arrR arrL.ElemType
                 | _ -> lBare
             | Elementwise ->
                 match lBare, rBare with
@@ -6421,6 +6498,148 @@ and bindLetPatVar (env: TypeEnv) (name: string) (identity: ArrayIdentity option)
         | None -> bindVarFull name varId tValue.Type identity assign (Some tValue) env
     (varId, env')
 
+/// Leaf (name, type) list for a `head :: tail` destructure of `scrutTy`.
+///
+/// SINGLE SOURCE OF TRUTH for cons-pattern typing. Four call sites need it —
+/// top-level `let` (checkDecl/DeclLet), block-scoped `let` (inferBlock's
+/// TStmtLet), `let static` (checkDecl/DeclStatic) and let-as-expression
+/// (inferLetBinding) — and the rules below MUST NOT drift between them: the
+/// original defect was that only one site knew them, so the other three handed
+/// every leaf a fresh, unconstrained type variable (which then zonked to the
+/// default Float64) and let Lowering project positionally (so `tail` bound
+/// element 1 rather than the remainder).
+///
+/// The rules, all of which Lowering.subBindingValue mirrors on the VALUE side:
+///   * `::` is right-associative (Parser.parsePattern), so `a :: b :: rest`
+///     arrives as PatCons(a, PatCons(b, rest)). The chain is flattened to k
+///     leading leaves plus exactly ONE rest leaf.
+///   * Leading leaf i takes tuple element i; the rest leaf takes the whole
+///     REMAINDER, re-tupled.
+///   * A one-element remainder binds BARE: Blade has no 1-tuple (`(x)` is a
+///     parenthesized expression, and no surface pattern could take one apart).
+///   * Anything else is a hard error, never a silent fresh type var: the
+///     scrutinee is not a tuple, or it is too short to yield both the leading
+///     elements and a non-empty remainder, or a leaf is not a plain variable
+///     (a nested tuple / wildcard / literal leaf contributes a name count that
+///     no longer matches "one sub-binding per tuple slot", and the positional
+///     rule would silently shear against it).
+and consDestructureLeaves (env: TypeEnv) (scrutTy: IRType) (h: Pattern) (t: Pattern)
+                          : TypeResult<(string * IRType) list> =
+    let rec flattenCons (hp: Pattern) (tp: Pattern) : Pattern list * Pattern =
+        match tp.Kind with
+        | PatternKind.PatCons (h2, t2) ->
+            let (heads, rest) = flattenCons h2 t2
+            (hp :: heads, rest)
+        | _ -> ([hp], tp)
+    let (headPats, restPat) = flattenCons h t
+    let leafPats = headPats @ [restPat]
+    let resolvedTy = env.Subst.Resolve scrutTy
+    let leafNames =
+        leafPats |> List.map (fun p ->
+            match p.Kind with PatternKind.PatVar n -> Some n | _ -> None)
+    match resolvedTy with
+    | IRTTuple ts when ts.Length > headPats.Length
+                       && leafNames |> List.forall Option.isSome ->
+        let names = leafNames |> List.map Option.get
+        let k = headPats.Length
+        let tailTy =
+            match ts |> List.skip k with
+            | [single] -> single
+            | many -> IRTTuple many
+        let leafTys = (ts |> List.truncate k) @ [tailTy]
+        Ok (List.zip names (leafTys |> List.map (fun ty -> env.Subst.Resolve ty)))
+    | _ ->
+        let patText =
+            leafPats
+            |> List.map (fun p ->
+                match p.Kind with
+                | PatternKind.PatVar n -> n
+                | PatternKind.PatWildcard -> "_"
+                | _ -> "<pattern>")
+            |> String.concat " :: "
+        Error (PatternTypeMismatch (patText, resolvedTy))
+
+/// Declared field list of a struct-typed scrutinee, or [] when the type is not
+/// a registered struct. Shared by the PatStruct destructuring arms so they all
+/// read field types from the same place.
+and structFieldTypesOf (env: TypeEnv) (scrutTy: IRType) : (string * IRType) list =
+    match env.Subst.Resolve scrutTy with
+    | IRTNamed sName ->
+        match Map.tryFind sName env.TypeDefs with
+        | Some (TDIStruct (_, _, fields, _)) -> fields
+        | _ -> []
+    | _ -> []
+
+/// Flat leaves of a (possibly nested) tuple type, as (path, leafType) pairs in
+/// flat left-to-right order. `path` is the list of STRUCTURAL indices from the
+/// root down to that leaf, OUTERMOST FIRST: for ((α, β), γ) the leaves are
+/// ([0; 0], α), ([0; 1], β), ([1], γ) — i.e. get<0>(get<0>(x)), get<1>(get<0>(x)),
+/// get<1>(x). A non-tuple is one leaf reached by the empty path (the value
+/// itself).
+///
+/// WHY paths instead of a flat index: a flat projection IS the composition of
+/// the structural projections along that path. Expressing it that way lets
+/// expression position destructure a flat pattern with ordinary chained
+/// TExprTupleIndex nodes — TypedAst's node has no `isFlat` flag (only
+/// Lowering's IRTupleProj does), and adding one would ripple through TypedAst,
+/// Lowering, Zonk and five sites in this file. CodeGen's flat IRTupleProj arm
+/// already computes exactly this path at emit time and folds std::get over it
+/// in the same order, so the two agree on what a flat projection means.
+///
+/// LEAF ORDER MUST MATCH IR.flattenTupleLeaves. Declaration position takes its
+/// flat leaf TYPES from that function (checkDecl's PatTuple arm) while
+/// expression position takes its leaf PATHS from this one; if the orders
+/// disagreed, the same source text would destructure differently at top level
+/// and inside an expression — worse than the missing binding this exists to
+/// fix. The recursion below is deliberately the same shape (left-to-right
+/// collect over the elements, non-tuple = exactly one leaf), so
+///     flatTupleLeafPaths ty |> List.map snd = IR.flattenTupleLeaves ty
+/// holds for every type by structural induction.
+and flatTupleLeafPaths (ty: IRType) : (int list * IRType) list =
+    match ty with
+    | IRTTuple ts ->
+        ts
+        |> List.mapi (fun i t ->
+               flatTupleLeafPaths t |> List.map (fun (path, leafTy) -> (i :: path, leafTy)))
+        |> List.concat
+    | _ -> [([], ty)]
+
+/// Desugar a destructuring `let` in EXPRESSION position into a CHAIN of
+/// single-name `TExprLet`s: one temp bound to the scrutinee, then one let per
+/// leaf bound to its projection out of that temp, innermost-out.
+///
+/// WHY a chain instead of the SubBindings mechanism the declaration and
+/// statement forms use: `TExprLet` is `name * varId * value * body` — one
+/// name, no sub-binding slot — and widening it would ripple through ~13 use
+/// sites across TypeCheck, Lowering and Zonk. wrapMutualReturnBody already
+/// binds its return-tuple leaves with exactly this nested-let shape, so the
+/// desugar needs no DU change, no Zonk change and no Lowering change.
+///
+/// What it fixes: every leaf previously got a fresh type variable and a varId
+/// that the single emitted `TExprLet` did NOT bind, so any body reference to a
+/// leaf lowered to an IRId that nothing introduces.
+///
+/// Each leaf supplies its own value-builder rather than a positional index, so
+/// wildcard slots (which bind nothing) cannot shift the projections of the
+/// leaves after them, and struct leaves can project by field instead.
+and destructureLetChain (env: TypeEnv) (tValue: TypedExpr)
+                        (leaves: (string * IRType * (TypedExpr -> TypedExpr)) list)
+                        (body: Expr) : TypeResult<TypedExpr> =
+    let scrutTy = env.Subst.Resolve tValue.Type
+    let tmpId = env.Builder.FreshId()
+    let tmpName = "__destructure_src"
+    let tmpVar = mkTyped (TExprVar (tmpName, tmpId, None)) scrutTy
+    let prepared =
+        leaves |> List.map (fun (n, ty, mkValue) -> (n, ty, env.Builder.FreshId(), mkValue tmpVar))
+    let mutable env' = env
+    for (n, ty, leafId, _) in prepared do
+        env' <- bindVarSimple n leafId ty env'
+    inferExpr env' body |> Result.map (fun tBody ->
+        let withLeaves =
+            List.foldBack (fun (n, _ty, leafId, leafValue) acc ->
+                mkTyped (TExprLet (n, leafId, leafValue, acc)) tBody.Type) prepared tBody
+        mkTyped (TExprLet (tmpName, tmpId, tValue, withLeaves)) tBody.Type)
+
 and inferLetBinding env binding body : TypeResult<TypedExpr> =
     // Bidirectional checking pushes annotations into literal/constructor
     // positions — see inferLetBindingValue. Then dispatch on the binding
@@ -6435,49 +6654,145 @@ and inferLetBinding env binding body : TypeResult<TypedExpr> =
                 mkTyped (TExprLet (name, varId, tValue, tBody)) tBody.Type)
 
         | PatternKind.PatTuple pats ->
-            let mutable env' = env
-            // Resolve type and determine binding list
+            // A tuple destructure in expression position desugars to a nested
+            // let chain (see destructureLetChain). TWO pattern shapes are
+            // desugared, tried in the same priority order the declaration
+            // position uses (checkDecl's PatTuple arm):
+            //   STRUCTURAL — (w, z) against ((α, β), γ): one leaf per top-level
+            //     slot, each reached by ONE projection.
+            //   FLAT — (x, y, z) against ((α, β), γ): one leaf per FLATTENED
+            //     leaf, each reached by a PATH of projections. This shape used
+            //     to fall through to letValueOnlyChain and bind NOTHING, so
+            //     every name in it resurfaced later as UnboundVariable.
+            // Structural wins the tie (a flat tuple is its own flattening), so
+            // no program that already type-checked changes meaning here.
+            //
+            // WHY a path rather than a flat projection node: TypedAst's
+            // TExprTupleIndex has no flat flag (only Lowering's IRTupleProj
+            // does, and that node is reachable from the SubBindings path, not
+            // from expression position) — but a flat projection IS the
+            // composition of the structural projections along the path from the
+            // root to the leaf, so chaining ordinary TExprTupleIndex nodes says
+            // exactly the same thing with no DU change, no Lowering change and
+            // no Zonk change. flatTupleLeafPaths documents why its leaf order
+            // must (and does) agree with IR.flattenTupleLeaves, which is what
+            // the declaration-position arm flattens with.
             let resolvedTy = env.Subst.Resolve(tValue.Type)
-            let typeList =
+            let intLit i = mkTyped (TExprLit (LitInt (int64 i))) (IRTScalar ETInt64)
+            // Fold one leaf's path into chained projections, innermost first.
+            // Each intermediate node is given the type it actually has, read
+            // back out of its parent's resolved tuple type: Lowering's
+            // TExprTupleIndex arm only emits a static IRTupleProj when the
+            // OPERAND's type is an IRTTuple, so an intermediate typed wrongly
+            // would silently divert the rest of the chain onto the poly-pack
+            // path (IRPolyIndex) — a fresh miscompile rather than a fix.
+            let projectPath (path: int list) (src: TypedExpr) : TypedExpr =
+                path |> List.fold (fun (acc: TypedExpr) idx ->
+                    let elemTy =
+                        match env.Subst.Resolve acc.Type with
+                        | IRTTuple ts when idx < ts.Length -> ts.[idx]
+                        // Unreachable: every path here was produced FROM this
+                        // very type. Keeping the parent's type (rather than a
+                        // fresh variable) at least leaves the node internally
+                        // consistent if that ever stops holding.
+                        | other -> other
+                    mkTyped (TExprTupleIndex (acc, intLit idx)) elemTy) src
+            let structural =
                 match resolvedTy with
-                | IRTTuple ts ->
-                    if pats.Length = ts.Length then ts
-                    else
-                        let flat = IR.flattenTupleLeaves resolvedTy
-                        if pats.Length = flat.Length then flat
-                        else ts
-                | _ -> []
-            pats |> List.iteri (fun i p ->
-                match p.Kind with
-                | PatternKind.PatVar n ->
-                    let vid = env.Builder.FreshId()
-                    let eTy =
-                        if i < typeList.Length then env.Subst.Resolve(typeList.[i])
-                        else env.Subst.Fresh()
-                    env' <- bindVarSimple n vid eTy env'
-                | PatternKind.PatWildcard -> ()
-                | _ ->
-                    for n in patternNames p do
-                        env' <- bindVarSimple n (env.Builder.FreshId()) (env.Subst.Fresh()) env')
-            inferExpr env' body |> Result.map (fun tBody ->
-                let name = pats |> List.tryPick (fun p -> match p.Kind with PatternKind.PatVar n -> Some n | _ -> None)
-                           |> Option.defaultValue "_"
-                mkTyped (TExprLet (name, env.Builder.FreshId(), tValue, tBody)) tBody.Type)
+                | IRTTuple ts when ts.Length = pats.Length ->
+                    Some (ts |> List.mapi (fun i t -> ([i], t)))
+                | _ -> None
+            // Flat leaves are only consulted when the structural arity does NOT
+            // match, and only when the pattern supplies exactly one leaf per
+            // flat leaf — the same test checkDecl's PatTuple arm applies before
+            // it switches to IR.flattenTupleLeaves.
+            let flat =
+                match structural, resolvedTy with
+                | None, IRTTuple _ ->
+                    let leaves = flatTupleLeafPaths resolvedTy
+                    if leaves.Length = pats.Length then Some leaves else None
+                | _ -> None
+            // Wildcards and compound leaves bind no let, in EITHER shape. A
+            // compound leaf would need a recursive desugar; leaving its names
+            // unbound turns a silent dangling-IRId miscompile into an honest
+            // UnboundVariable.
+            let leavesOf (leafInfo: (int list * IRType) list) =
+                pats
+                |> List.mapi (fun i p -> (i, p))
+                |> List.choose (fun (i, p) ->
+                    match p.Kind with
+                    | PatternKind.PatVar n ->
+                        let (path, leafTy) = leafInfo.[i]
+                        Some (n, env.Subst.Resolve leafTy, projectPath path)
+                    | _ -> None)
+            let chosen = if structural.IsSome then structural else flat
+            match chosen with
+            | Some leafInfo -> destructureLetChain env tValue (leavesOf leafInfo) body
+            | None -> letValueOnlyChain env tValue body
 
         | PatternKind.PatCons (headPat, tailPat) ->
-            let mutable env' = env
-            for n in patternNames headPat @ patternNames tailPat do
-                env' <- bindVarSimple n (env.Builder.FreshId()) (env.Subst.Fresh()) env'
-            inferExpr env' body |> Result.map (fun tBody ->
-                let name = patternNames headPat |> List.tryHead |> Option.defaultValue "_"
-                mkTyped (TExprLet (name, env.Builder.FreshId(), tValue, tBody)) tBody.Type)
+            // `let head :: tail = t` in expression position. Same leaf rules as
+            // every other cons site (consDestructureLeaves), and the same hard
+            // error when the scrutinee cannot be split — binding fresh type
+            // vars instead is exactly the miscompile the shared helper exists
+            // to prevent.
+            consDestructureLeaves env tValue.Type headPat tailPat
+            |> Result.bind (fun leafTys ->
+                let resolvedTy = env.Subst.Resolve(tValue.Type)
+                let elemTys = match resolvedTy with IRTTuple ts -> ts | _ -> []
+                let intLit i = mkTyped (TExprLit (LitInt (int64 i))) (IRTScalar ETInt64)
+                let lastIdx = leafTys.Length - 1
+                let leaves =
+                    leafTys
+                    |> List.mapi (fun i (n, ty) ->
+                        let mkValue (src: TypedExpr) =
+                            if i = lastIdx then
+                                // REST leaf: the remainder, re-tupled from its
+                                // own index onward — bare when one element
+                                // (Blade has no 1-tuple). Identical rule to
+                                // Lowering.subBindingValue, so the leaf's
+                                // declared type and its value always agree.
+                                let rest =
+                                    [ for j in i .. elemTys.Length - 1 ->
+                                        mkTyped (TExprTupleIndex (src, intLit j)) elemTys.[j] ]
+                                match rest with
+                                | [single] -> single
+                                | many -> mkTyped (TExprTuple many) ty
+                            else mkTyped (TExprTupleIndex (src, intLit i)) ty
+                        (n, ty, mkValue))
+                destructureLetChain env tValue leaves body)
+
+        | PatternKind.PatStruct (_, fieldPats) ->
+            // `let Point { x, y } = p` in expression position. Field leaves
+            // project by NAME (TExprField), so a missing/extra field cannot
+            // shift the others the way a positional index would.
+            let fieldTypes = structFieldTypesOf env tValue.Type
+            if fieldTypes.IsEmpty then letValueOnlyChain env tValue body
+            else
+                let leaves =
+                    fieldPats
+                    |> List.choose (fun (fieldName, p) ->
+                        match p.Kind, fieldTypes |> List.tryFindIndex (fun (fn, _) -> fn = fieldName) with
+                        | PatternKind.PatVar n, Some idx ->
+                            let fTy = env.Subst.Resolve (snd fieldTypes.[idx])
+                            Some (n, fTy, fun (src: TypedExpr) ->
+                                     mkTyped (TExprField (src, fieldName, idx)) fTy)
+                        | _ -> None)
+                destructureLetChain env tValue leaves body
 
         | _ ->
-            let mutable env' = env
-            for n in patternNames binding.Pattern do
-                env' <- bindVarSimple n (env.Builder.FreshId()) (env.Subst.Fresh()) env'
-            inferExpr env' body |> Result.map (fun tBody ->
-                mkTyped (TExprLet ("_", env.Builder.FreshId(), tValue, tBody)) tBody.Type))
+            letValueOnlyChain env tValue body)
+
+/// Fallback for a destructuring `let` in expression position whose pattern the
+/// leaf desugar cannot describe (a tuple pattern whose arity matches NEITHER
+/// the scrutinee's structural slot count NOR its flat leaf count, a scrutinee
+/// that is not a tuple at all, an unregistered struct type, wildcard/literal/
+/// variant patterns). The VALUE is still bound to a temp so
+/// its effects and type survive; no leaf name is bound, because the only
+/// alternative on offer is the fresh-type-var-plus-unbound-varId shape that
+/// destructureLetChain exists to replace.
+and letValueOnlyChain (env: TypeEnv) (tValue: TypedExpr) (body: Expr) : TypeResult<TypedExpr> =
+    destructureLetChain env tValue [] body
 
 and inferMatch env scrutinee cases : TypeResult<TypedExpr> =
     inferExpr env scrutinee |> Result.bind (fun tScrutinee ->
@@ -6543,42 +6858,30 @@ and inferBlock env stmts finalExpr : TypeResult<TypedExpr> =
                          let prov = provenanceOfSurface curEnv binding.Value
                          if not (Set.isEmpty prov) then curEnv.Provenance.[varId] <- prov
                      | _ -> ())
-                    // Tuple destructuring in a block: bind the leaves AND
-                    // record them as SubBindings so Lowering emits their
-                    // projection lets (mirrors checkDecl's PatTuple path).
-                    // Previously SubBindings was left empty here, so the
-                    // leaf VarIds referenced by the rest of the block were
-                    // never introduced in the IR — dangling VarId at
-                    // validation for any in-body `let (x, y) = p`.
+                    // Destructuring in a block: bind the leaves AND record them
+                    // as SubBindings so Lowering emits their projection lets
+                    // (mirrors checkDecl's DeclLet path). Previously SubBindings
+                    // was left empty here, so the leaf VarIds referenced by the
+                    // rest of the block were never introduced in the IR —
+                    // dangling VarId at validation for any in-body
+                    // `let (x, y) = p`; and even after the tuple and cons arms
+                    // landed, a STRUCT pattern (`let Point { x, y } = p`) still
+                    // fell through and bound nothing at all, so both field names
+                    // surfaced later in the block as UnboundVariable.
+                    //
+                    // All three shapes now live in stmtDestructureBindings,
+                    // shared with the for-in body path (inferForIn) because a
+                    // loop body IS a block scope: the two must never disagree
+                    // about what a pattern binds or at what types.
                     let mutable subBindings : (string * IRId * IRType) list = []
-                    (match binding.Pattern.Kind with
-                     | PatternKind.PatTuple pats ->
-                        let resolvedTy = curEnv.Subst.Resolve(tValue.Type)
-                        let typeList =
-                            match resolvedTy with
-                            | IRTTuple ts ->
-                                if pats.Length = ts.Length then ts
-                                else
-                                    // Flat match: (x, y, z) against ((α,β), γ)
-                                    let flat = IR.flattenTupleLeaves resolvedTy
-                                    if pats.Length = flat.Length then flat else ts
-                            | _ -> []
-                        pats |> List.iteri (fun i p ->
-                            match p.Kind with
-                            | PatternKind.PatVar n ->
-                                let eTy =
-                                    if i < typeList.Length then curEnv.Subst.Resolve(typeList.[i])
-                                    else curEnv.Subst.Fresh()
-                                let subId = curEnv.Builder.FreshId()
-                                subBindings <- subBindings @ [(n, subId, eTy)]
-                                curEnv <- bindVarSimple n subId eTy curEnv
-                            | _ ->
-                                for n in patternNames p do
-                                    let subId = curEnv.Builder.FreshId()
-                                    let eTy = curEnv.Subst.Fresh()
-                                    subBindings <- subBindings @ [(n, subId, eTy)]
-                                    curEnv <- bindVarSimple n subId eTy curEnv)
-                     | _ -> ())
+                    // Shape tag handed to Lowering (see TypedAst.DestructureShape).
+                    let mutable destructure = DSPositional
+                    (match stmtDestructureBindings curEnv binding.Pattern tValue.Type with
+                     | Error e -> err <- Some e
+                     | Ok (leafEnv, leaves, shape) ->
+                        curEnv <- leafEnv
+                        subBindings <- leaves
+                        destructure <- shape)
                     // Mutual-group check-point (block-level twin of the
                     // top-level DeclLet hook).
                     let mutualChecks =
@@ -6602,6 +6905,7 @@ and inferBlock env stmts finalExpr : TypeResult<TypedExpr> =
                         Name = name; VarId = varId; Type = tValue.Type
                         Identity = identity; IsMutable = (assign <> ReadOnly); Value = tValue
                         SubBindings = subBindings |> List.map (fun (n, id, ty) -> (n, id, curEnv.Subst.Resolve ty))
+                        Destructure = destructure
                         PostChecks = postChecks
                     }
                     typedStmts <- typedStmts @ [TStmtLet tb]
@@ -6644,6 +6948,94 @@ and inferBlock env stmts finalExpr : TypeResult<TypedExpr> =
             mkTyped (TExprBlock (typedStmts, Some tF)) tF.Type)
         | None -> Ok (mkTyped (TExprBlock (typedStmts, None)) IRTUnit)
 
+/// Leaf bindings for a destructuring `let` in STATEMENT position. Returns the
+/// environment extended with every leaf, the (name, id, type) sub-binding list
+/// Lowering projects from (Lowering.subBindingValue), and the shape tag telling
+/// it HOW to project (TypedAst.DestructureShape).
+///
+/// WHY it is shared: a for-in body is a block scope, so inferBlock's TStmtLet
+/// and inferForIn's StmtLet must answer identically about what a pattern binds
+/// and at what types. They previously did not — inferBlock handled tuple and
+/// cons but not struct, and inferForIn hardcoded `SubBindings = []` for every
+/// shape — and the failure mode of a missing arm is silent: the primary binding
+/// takes the synthetic "_", no leaf id is ever introduced, and each leaf name
+/// resurfaces far away as UnboundVariable (or, if something else happens to
+/// bind the name, as an IRId that nothing declares).
+///
+/// The leaf TYPES come from the same helpers checkDecl/DeclLet reads
+/// (consDestructureLeaves for cons, structFieldTypesOf for struct) so statement
+/// position and declaration position cannot drift apart on the typing rules.
+///
+/// A non-destructuring pattern records nothing: the primary binding already
+/// covers a plain name, and a wildcard/literal binds no name at all.
+and stmtDestructureBindings (env: TypeEnv) (pat: Pattern) (valueTy: IRType)
+                            : TypeResult<TypeEnv * (string * IRId * IRType) list * DestructureShape> =
+    let mutable e = env
+    let mutable subs : (string * IRId * IRType) list = []
+    let bindLeaf (n: string) (ty: IRType) =
+        let subId = e.Builder.FreshId()
+        subs <- subs @ [(n, subId, ty)]
+        e <- bindVarSimple n subId ty e
+    // A compound leaf (nested tuple/struct pattern) is not recursively
+    // destructured here; its names bind at fresh type vars so a later reference
+    // resolves to *something* instead of cascading UnboundVariable errors.
+    // Same conservative rule as checkDecl/DeclLet.
+    let bindCompound (p: Pattern) =
+        for n in patternNames p do bindLeaf n (e.Subst.Fresh())
+    match pat.Kind with
+    | PatternKind.PatTuple pats ->
+        let resolvedTy = e.Subst.Resolve valueTy
+        let typeList =
+            match resolvedTy with
+            | IRTTuple ts ->
+                if pats.Length = ts.Length then ts
+                else
+                    // Flat match: (x, y, z) against ((α,β), γ)
+                    let flat = IR.flattenTupleLeaves resolvedTy
+                    if pats.Length = flat.Length then flat else ts
+            | _ -> []
+        pats |> List.iteri (fun i p ->
+            match p.Kind with
+            | PatternKind.PatVar n ->
+                let eTy =
+                    if i < typeList.Length then e.Subst.Resolve(typeList.[i])
+                    else e.Subst.Fresh()
+                bindLeaf n eTy
+            | _ -> bindCompound p)
+        Ok (e, subs, DSPositional)
+    | PatternKind.PatCons (h, t) ->
+        // `let head :: tail = tup`. The flatten/typing/reject rules live in
+        // consDestructureLeaves, shared with the top-level, `let static` and
+        // expression-position forms. A scrutinee that cannot be split is a hard
+        // error, never a set of fresh type vars: unconstrained leaf vars zonk to
+        // the default Float64 while Lowering projects positionally, which is the
+        // exact silent miscompile that helper exists to prevent.
+        consDestructureLeaves env valueTy h t
+        |> Result.map (fun leaves ->
+            for (n, ty) in leaves do bindLeaf n ty
+            (e, subs, DSConsRest))
+    | PatternKind.PatStruct (_, fieldPats) ->
+        // `let Point { x, y } = p`. Leaves are matched BY NAME, never by
+        // position: Lowering.subBindingValue projects a struct sub-binding with
+        // IRFieldAccess on the leaf's OWN name, so a missing or extra field
+        // pattern must not shift the field any other leaf reads — and the
+        // declared type has to be looked up the same way for the two to agree.
+        // structFieldTypesOf returns [] for a scrutinee that is not a registered
+        // struct, so every leaf then falls back to a fresh var rather than
+        // silently taking some other field's type.
+        let fieldTypeMap = Map.ofList (structFieldTypesOf env valueTy)
+        for (fieldName, p) in fieldPats do
+            (match p.Kind with
+             | PatternKind.PatVar n ->
+                let eTy =
+                    match Map.tryFind fieldName fieldTypeMap with
+                    | Some ty -> e.Subst.Resolve ty
+                    | None -> e.Subst.Fresh()
+                bindLeaf n eTy
+             | _ -> bindCompound p)
+        Ok (e, subs, DSPositional)
+    | _ -> Ok (env, [], DSPositional)
+
 /// Infer one for-in loop statement. Recursive so loops nest to any depth
 /// (required by the ML-module layers and grad-generated adjoint loops).
 /// The loop variable binds as Int64 in the body scope; body lets stay local
@@ -6675,10 +7067,28 @@ and inferForIn (env: TypeEnv) (varName: string) (rangeExpr: Expr) (bodyStmts: St
                             let bId = bodyEnv.Builder.FreshId()
                             let assign = assignOfBindingMut binding.Mutability
                             bodyEnv <- bindVarFull bName bId tValue.Type None assign (Some tValue) bodyEnv
+                            // Destructuring inside a loop body. This path used
+                            // to hardcode `SubBindings = []` / DSPositional, so
+                            // EVERY destructuring shape — tuple, cons and
+                            // struct alike — bound nothing: the primary took
+                            // the synthetic "_" and each leaf name resurfaced
+                            // later in the loop as UnboundVariable. Routed
+                            // through the same stmtDestructureBindings
+                            // inferBlock uses, because a loop body IS a block
+                            // scope and the two must not answer differently.
+                            let mutable subBindings : (string * IRId * IRType) list = []
+                            let mutable destructure = DSPositional
+                            (match stmtDestructureBindings bodyEnv binding.Pattern tValue.Type with
+                             | Error e -> bodyErr <- Some e
+                             | Ok (leafEnv, leaves, shape) ->
+                                bodyEnv <- leafEnv
+                                subBindings <- leaves
+                                destructure <- shape)
                             let tb : TypedBinding = {
                                 Name = bName; VarId = bId; Type = tValue.Type
                                 Identity = None; IsMutable = (assign <> ReadOnly); Value = tValue
-                                SubBindings = []; PostChecks = []
+                                SubBindings = subBindings |> List.map (fun (n, id, ty) -> (n, id, bodyEnv.Subst.Resolve ty))
+                                Destructure = destructure; PostChecks = []
                             }
                             typedBodyStmts <- typedBodyStmts @ [TStmtLet tb]
                         | Error e -> bodyErr <- Some e
@@ -7363,6 +7773,15 @@ and checkDecl (env: TypeEnv) (decl: Decl) : TypeResult<TypedDecl * TypeEnv> =
 
             // Handle destructuring at top level — collect sub-bindings for Lowering
             let mutable subBindings : (string * IRId * IRType) list = []
+            // Shape tag handed to Lowering (see TypedAst.DestructureShape). Only
+            // the PatCons arm below moves it off DSPositional.
+            let mutable destructure = DSPositional
+            // A destructuring pattern that cannot be satisfied by the scrutinee's
+            // real type is a type ERROR, but the env-building fold below is a pure
+            // expression with nowhere to return one from. Park it here and surface
+            // it just before the binding is assembled; silently binding fresh type
+            // vars instead is exactly how `head :: tail` used to miscompile.
+            let mutable patternError : TypeError option = None
             let env' =
                 match binding.Pattern.Kind with
                 | PatternKind.PatTuple pats ->
@@ -7396,25 +7815,34 @@ and checkDecl (env: TypeEnv) (decl: Decl) : TypeResult<TypedDecl * TypeEnv> =
                             subBindings <- subBindings @ [(n, subId, eTy)]
                             bindVarSimple n subId eTy e2) e) env'
                 | PatternKind.PatCons (h, t) ->
-                    let e1 = patternNames h |> List.fold (fun e n ->
-                        let subId = env.Builder.FreshId()
-                        let eTy = env.Subst.Fresh()
-                        subBindings <- subBindings @ [(n, subId, eTy)]
-                        bindVarSimple n subId eTy e) env'
-                    patternNames t |> List.fold (fun e n ->
-                        let subId = env.Builder.FreshId()
-                        let eTy = env.Subst.Fresh()
-                        subBindings <- subBindings @ [(n, subId, eTy)]
-                        bindVarSimple n subId eTy e) e1
+                    // `let head :: tail = tup` splits an n-tuple into element 0
+                    // and the REMAINDER — `tail` is the (n-1)-tuple (2, 3), not
+                    // the single element 2. This arm used to hand every name a
+                    // fresh type variable and let Lowering project positionally,
+                    // which produced both defects at once: `tail` bound element
+                    // 1, and nothing ever constrained either type variable so
+                    // both zonked to the default Float64.
+                    //
+                    // The flatten/typing/reject rules now live in
+                    // consDestructureLeaves, shared with the block-scoped,
+                    // `let static` and expression-position forms so the four
+                    // sites cannot drift apart.
+                    match consDestructureLeaves env tValue.Type h t with
+                    | Error e ->
+                        patternError <- Some e
+                        env'
+                    | Ok leaves ->
+                        destructure <- DSConsRest
+                        leaves
+                        |> List.fold (fun e (n, ty) ->
+                            let subId = env.Builder.FreshId()
+                            subBindings <- subBindings @ [(n, subId, ty)]
+                            bindVarSimple n subId ty e) env'
                 | PatternKind.PatStruct (structName, fieldPats) ->
                     // Look up struct field types from the type definition
-                    let structFields =
-                        match env.Subst.Resolve(tValue.Type) with
-                        | IRTNamed sName ->
-                            match Map.tryFind sName env.TypeDefs with
-                            | Some (TDIStruct (_, _, fields, _)) -> fields
-                            | _ -> []
-                        | _ -> []
+                    // (shared with the expression-position PatStruct arm so
+                    // both read the field list from the same place).
+                    let structFields = structFieldTypesOf env tValue.Type
                     let fieldTypeMap = Map.ofList structFields
                     fieldPats |> List.fold (fun e (fieldName, pat) ->
                         match pat.Kind with
@@ -7431,6 +7859,11 @@ and checkDecl (env: TypeEnv) (decl: Decl) : TypeResult<TypedDecl * TypeEnv> =
                             bindVarSimple n subId eTy e2) e) env'
                 | _ -> env'
 
+            // Surface a destructuring pattern that the scrutinee's type cannot
+            // satisfy (see patternError above) before anything else is built —
+            // the sub-binding ids are already allocated at this point, but a
+            // failed decl never reaches Lowering so they simply go unused.
+            if patternError.IsSome then Error patternError.Value else
             // Mutual-group check-point: an annotation naming a group makes
             // this let the introduce-site (unless the RHS is a call already
             // checked at its declared return). Check IRIds allocate after
@@ -7453,6 +7886,7 @@ and checkDecl (env: TypeEnv) (decl: Decl) : TypeResult<TypedDecl * TypeEnv> =
                 Name = name; VarId = varId; Type = env.Subst.Resolve(tValue.Type)
                 Identity = identity; IsMutable = (assign <> ReadOnly); Value = tValue
                 SubBindings = subBindings |> List.map (fun (n, id, ty) -> (n, id, env.Subst.Resolve ty))
+                Destructure = destructure
                 PostChecks = postChecks
             }
             (TDeclLet tb, env')))))
@@ -7501,9 +7935,37 @@ and checkDecl (env: TypeEnv) (decl: Decl) : TypeResult<TypedDecl * TypeEnv> =
             | None -> inferLetBindingValue env binding
         inferred |> Result.bind (fun tValue ->
             let name = match binding.Pattern.Kind with PatternKind.PatVar n -> n | _ -> "_"
-            // Reuse pre-pass varId if this static was already pre-registered
+            // Reuse the pre-pass varId if this static was already pre-registered
+            // — but ONLY for a plain `let static x = ...`.
+            //
+            // checkModule's pre-pass (the fold that "registers static functions
+            // and static values with placeholder types") exists so a FORWARD
+            // reference resolves: `let static a = b + 1` written before
+            // `let static b = 2` needs `b` bound at a placeholder type whose
+            // varId the real decl then adopts, which is what the unify below
+            // accomplishes. The pre-pass derives its key from the binding's
+            // pattern exactly as this arm does — PatVar gives the real name,
+            // every other pattern gives the synthetic "_".
+            //
+            // For a DESTRUCTURING static that pre-registration is both useless
+            // and actively wrong. Useless: no source reference can name "_", and
+            // the pre-pass registers NONE of the pattern's real leaf names, so
+            // it buys no forward reference for `head`/`x`/`y`. Wrong: every
+            // destructured static in a module registers under the SAME key "_",
+            // so with two of them the second's `lookupVar "_"` finds the FIRST
+            // one's varId. The two module bindings then share one IRId (one
+            // C++ `__tup_N` per CodeGen.bindingCppName, emitted twice) and, at
+            // least as bad, the `unify` below welds their two unrelated types
+            // together. Allocating a fresh id whenever the pattern destructures
+            // is the fix at the one place that can distinguish the two cases;
+            // the pre-pass's "_" entry is simply left unconsulted, which is what
+            // it always effectively was for this shape.
+            let preRegistered =
+                match binding.Pattern.Kind with
+                | PatternKind.PatVar _ -> lookupVar name env
+                | _ -> None
             let varId =
-                match lookupVar name env with
+                match preRegistered with
                 | Some existing ->
                     // Unify pre-pass type with checked type so forward references resolve
                     let _ = unify env.Subst existing.Type tValue.Type
@@ -7518,11 +7980,26 @@ and checkDecl (env: TypeEnv) (decl: Decl) : TypeResult<TypedDecl * TypeEnv> =
                 | Some s -> bindVarPoly name varId tValue.Type None ReadOnly (Some tValue) s env
                 | None -> bindVarFull name varId tValue.Type None ReadOnly (Some tValue) env
 
-            // Tuple destructuring for `let static (a, b) = expr`. Mirrors the
-            // PatTuple branch of DeclLet — sub-bindings become individually
-            // resolvable names downstream. PatCons / PatStruct destructuring
-            // for static bindings is not yet covered (no test pressure yet).
+            // Tuple, cons and struct destructuring for `let static (a, b) =
+            // expr` / `let static head :: tail = expr` / `let static
+            // Point { x, y } = expr`. Mirrors the corresponding branches of
+            // DeclLet — sub-bindings become individually resolvable names
+            // downstream.
+            //
+            // Note the division of labour with StaticEval: its bindPattern
+            // folds PatVar/PatTuple/PatStruct leaves into env.StaticValues, so
+            // those leaves lower to compile-time constants. It has no PatCons
+            // case, so cons leaves get no static value and Lowering's
+            // TDeclStatic path falls back to projecting them out of the primary
+            // binding (subBindingValue) — which is exactly what DSConsRest
+            // below tells it to do.
             let mutable subBindings : (string * IRId * IRType) list = []
+            let mutable destructure = DSPositional
+            // Same parking spot as DeclLet's: the env-building fold is a pure
+            // expression with nowhere to return an error from, so a
+            // non-splittable cons pattern is surfaced just before the binding
+            // is assembled.
+            let mutable patternError : TypeError option = None
             let env'' =
                 match binding.Pattern.Kind with
                 | PatternKind.PatTuple pats ->
@@ -7550,12 +8027,58 @@ and checkDecl (env: TypeEnv) (decl: Decl) : TypeResult<TypedDecl * TypeEnv> =
                             let eTy = env.Subst.Fresh()
                             subBindings <- subBindings @ [(n, subId, eTy)]
                             bindVarSimple n subId eTy e2) e) env'
+                | PatternKind.PatCons (h, t) ->
+                    match consDestructureLeaves env tValue.Type h t with
+                    | Error e ->
+                        patternError <- Some e
+                        env'
+                    | Ok leaves ->
+                        destructure <- DSConsRest
+                        leaves
+                        |> List.fold (fun e (n, ty) ->
+                            let subId = env.Builder.FreshId()
+                            subBindings <- subBindings @ [(n, subId, ty)]
+                            bindVarSimple n subId ty e) env'
+                | PatternKind.PatStruct (_, fieldPats) ->
+                    // `let static Point { x, y } = Point { x = 3, y = 4 }`.
+                    // This arm did not exist, so a struct pattern under
+                    // `let static` recorded no sub-bindings at all and both
+                    // field names surfaced as UnboundVariable — even though
+                    // StaticEval.bindPattern had already folded each leaf to a
+                    // compile-time value. That fold is what Lowering's
+                    // TDeclStatic path prefers (a direct constant per leaf);
+                    // the sub-binding recorded here is what gives that constant
+                    // its name, IRId and type, so without it the value existed
+                    // with nothing to attach it to.
+                    //
+                    // Field types come from structFieldTypesOf — the same
+                    // declared-field list DeclLet reads — and leaves are matched
+                    // BY NAME, so a missing or extra field pattern cannot shift
+                    // the field any other leaf projects (Lowering's struct
+                    // sub-binding emits IRFieldAccess on the leaf's own name).
+                    let fieldTypeMap = Map.ofList (structFieldTypesOf env tValue.Type)
+                    fieldPats |> List.fold (fun e (fieldName, p) ->
+                        match p.Kind with
+                        | PatternKind.PatVar n ->
+                            let subId = env.Builder.FreshId()
+                            let eTy =
+                                Map.tryFind fieldName fieldTypeMap
+                                |> Option.defaultWith (fun () -> env.Subst.Fresh())
+                            subBindings <- subBindings @ [(n, subId, eTy)]
+                            bindVarSimple n subId eTy e
+                        | _ -> patternNames p |> List.fold (fun e2 n ->
+                            let subId = env.Builder.FreshId()
+                            let eTy = env.Subst.Fresh()
+                            subBindings <- subBindings @ [(n, subId, eTy)]
+                            bindVarSimple n subId eTy e2) e) env'
                 | _ -> env'
 
+            if patternError.IsSome then Error patternError.Value else
             let tb : TypedBinding = {
                 Name = name; VarId = varId; Type = env.Subst.Resolve(tValue.Type)
                 Identity = None; IsMutable = false; Value = tValue
                 SubBindings = subBindings |> List.map (fun (n, id, ty) -> (n, id, env.Subst.Resolve ty))
+                Destructure = destructure
                 PostChecks = []
             }
             Ok (TDeclStatic tb, env''))

--- a/rewrite/blade-compiler/TypedAst.fs
+++ b/rewrite/blade-compiler/TypedAst.fs
@@ -331,12 +331,37 @@ and TypedBinding = {
     Value: TypedExpr
     /// Destructured sub-bindings: (name, varId, type) for PatTuple/PatCons/PatStruct
     SubBindings: (string * IRId * IRType) list
+    /// How Lowering must derive each SubBindings entry from the primary value.
+    /// See DestructureShape — without it a cons pattern is indistinguishable
+    /// from a tuple pattern by the time lowering runs, and `head :: tail`
+    /// miscompiles into two positional projections.
+    Destructure: DestructureShape
     /// Constraint guards to run right after this binding (mutual-group joint
     /// checks). IRIds are allocated by the checker directly after the
     /// SubBinding ids — module emission is IRId-ordered, so lowering-time
     /// fresh ids would sort to the end and run too late.
     PostChecks: (IRId * TypedExpr) list
 }
+
+/// How a TypedBinding's SubBindings relate to the primary binding's value.
+///
+/// The tag lives on the BINDING rather than on each sub-binding entry because
+/// SubBindings' element shape `(name, varId, type)` is consumed positionally by
+/// Cli.fs, Ide.fs and Zonk.fs; widening the tuple would ripple through all of
+/// them for information only Lowering needs.
+and DestructureShape =
+    /// Sub-binding i is element i of a tuple (or, for a struct scrutinee, the
+    /// field with the sub-binding's own name). Also the shape of a binding with
+    /// no destructuring at all.
+    | DSPositional
+    /// Cons split over a tuple scrutinee. `::` is right-associative, so a chain
+    /// `a :: b :: rest` is flattened by the checker into leading leaves [a; b]
+    /// plus one REST leaf. Every leaf but the LAST is positional as usual; the
+    /// last one takes the whole remainder — all elements from its own index
+    /// onward, re-tupled — rather than the single element at its index. A
+    /// one-element remainder binds that element bare, because Blade has no
+    /// 1-tuple: `(x)` is just `x`.
+    | DSConsRest
 
 and TypedFunctionDecl = {
     Name: string

--- a/rewrite/blade-compiler/tests/Expect.fs
+++ b/rewrite/blade-compiler/tests/Expect.fs
@@ -9,16 +9,361 @@ open System
 // Value Checking Infrastructure
 // ============================================================================
 
+/// Where a "(rejects)" probe is required to be rejected.
+///
+/// A reject-probe asserts that the compiler REFUSES a program. Without a
+/// pinned stage, "refused" degenerates into "something, somewhere, went
+/// wrong" — a dead toolchain, garbage generated C++, or a runtime crash all
+/// look identical to a deliberate rejection, and the probe reports green
+/// while nothing was actually verified. Pinning the stage makes the probe
+/// assert a specific compiler behaviour instead of mere failure:
+///
+///   RejectAtLower   — parse / typecheck / IR lowering must reject it.
+///   RejectAtCodegen — lowering succeeds and codegen deliberately emits a
+///                     `#error` guard, which the C++ compiler then hits.
+///
+/// Corpus syntax (one line, anywhere in the file):
+///   // REJECT-AT: lower
+///   // REJECT-AT: codegen
+type RejectStage =
+    | RejectAtLower
+    | RejectAtCodegen
+
+/// Read the `// REJECT-AT:` directive out of a test source.
+///
+/// The directive is optional: the overwhelming majority of reject-probes are
+/// rejected during lowering, so an ABSENT directive means RejectAtLower. An
+/// unrecognized value is NOT defaulted — silently reading `// REJECT-AT: lowr`
+/// as "lower" would reintroduce exactly the class of bug the directive exists
+/// to close, so a bad value is a corpus authoring error and fails loudly.
+/// Repeated directives must agree, for the same reason.
+let parseRejectStage (source: string) : RejectStage =
+    let stages =
+        source.Split([|'\n'; '\r'|], StringSplitOptions.RemoveEmptyEntries)
+        |> Array.choose (fun line ->
+            let trimmed = line.Trim()
+            if trimmed.StartsWith("// REJECT-AT:") then
+                Some (trimmed.Substring(13).Trim())
+            else None)
+        |> Array.toList
+    match stages |> List.distinct with
+    | [] -> RejectAtLower
+    | [ one ] ->
+        match one.ToLowerInvariant() with
+        | "lower" -> RejectAtLower
+        | "codegen" -> RejectAtCodegen
+        | other ->
+            failwithf "// REJECT-AT: '%s' is not a known reject stage (expected 'lower' or 'codegen')" other
+    | many ->
+        failwithf "conflicting // REJECT-AT: directives in one test: %s" (String.concat ", " many)
+
 /// Expected value for a variable
 type ExpectedValue =
     | ExpectedScalar of string * float
     | ExpectedBool of string * bool
     | ExpectedArray1D of string * float list
+    | ExpectedArray1DBool of string * bool list
     | ExpectedArray2D of string * float list list
     | ExpectedComplex of string * float * float
     | ExpectedArray1DComplex of string * (float * float) list
     | ExpectedString of string * string
     | ExpectedArray1DString of string * string list
+
+/// Split the BODY of a bracketed list at the commas that sit at nesting
+/// depth zero, so `[0, 1], [20, 21]` yields the two row texts rather than
+/// four element texts. Depth counts `[` and `(` alike, and commas inside a
+/// quoted region are ignored, so this is safe for every list flavour the
+/// EXPECT grammar admits.
+let private splitTopLevelCommas (inner: string) : string list =
+    let parts = ResizeArray<string>()
+    let cur = System.Text.StringBuilder()
+    let mutable depth = 0
+    let mutable inQuotes = false
+    let mutable escaped = false
+    for c in inner do
+        if escaped then
+            cur.Append(c) |> ignore
+            escaped <- false
+        elif c = '\\' then
+            cur.Append(c) |> ignore
+            escaped <- true
+        elif c = '"' then
+            cur.Append(c) |> ignore
+            inQuotes <- not inQuotes
+        elif inQuotes then
+            cur.Append(c) |> ignore
+        else
+            match c with
+            | '[' | '(' ->
+                depth <- depth + 1
+                cur.Append(c) |> ignore
+            | ']' | ')' ->
+                depth <- depth - 1
+                cur.Append(c) |> ignore
+            | ',' when depth = 0 ->
+                parts.Add(cur.ToString())
+                cur.Clear() |> ignore
+            | _ -> cur.Append(c) |> ignore
+    if cur.Length > 0 then parts.Add(cur.ToString())
+    parts |> List.ofSeq
+
+/// Parse a bracketed float list `[1.0, 2.0, 3.0]`.
+///
+/// Returns None — rather than substituting a value — when ANY element fails
+/// to parse. The previous version mapped an unparseable element to 0.0, which
+/// turned a typo into a silent expectation of zero: `// EXPECT: v = [1, x, 3]`
+/// became "the middle element must be 0". A pin either parses in full or is
+/// reported as malformed; there is no third, quietly-weakened state.
+let private tryParseFloatList (s: string) : float list option =
+    let t = s.Trim()
+    if not (t.StartsWith("[") && t.EndsWith("]")) then None
+    else
+        let inner = t.Substring(1, t.Length - 2).Trim()
+        if String.IsNullOrWhiteSpace(inner) then Some []
+        else
+            let parsed =
+                splitTopLevelCommas inner
+                |> List.map (fun x ->
+                    match Double.TryParse(x.Trim()) with
+                    | true, v -> Some v
+                    | false, _ -> None)
+            if parsed |> List.forall Option.isSome then Some (parsed |> List.map Option.get)
+            else None
+
+/// Parse a nested float list `[[a, b], [c, d]]`. Bracket-aware (rows are
+/// split on depth-0 commas, not on a literal "], [" spelling) and strict in
+/// the same sense as tryParseFloatList: one bad element fails the whole pin.
+let internal tryParse2DList (s: string) : float list list option =
+    let t = s.Trim()
+    if not (t.StartsWith("[") && t.EndsWith("]")) then None
+    else
+        let inner = t.Substring(1, t.Length - 2).Trim()
+        if String.IsNullOrWhiteSpace(inner) then Some []
+        else
+            let rows = splitTopLevelCommas inner |> List.map tryParseFloatList
+            if rows |> List.forall Option.isSome then Some (rows |> List.map Option.get)
+            else None
+
+/// Parse a single complex pair `(re, im)` returning (re, im) on success.
+/// Tolerates surrounding whitespace and accepts both `1` and `1.0` for
+/// each component (matching the existing Double.TryParse convention).
+let private parseComplexPair (s: string) : (float * float) option =
+    let t = s.Trim()
+    if t.StartsWith("(") && t.EndsWith(")") then
+        let inner = t.Substring(1, t.Length - 2)
+        match inner.Split([|','|], 2) with
+        | [| reStr; imStr |] ->
+            match Double.TryParse(reStr.Trim()), Double.TryParse(imStr.Trim()) with
+            | (true, re), (true, im) -> Some (re, im)
+            | _ -> None
+        | _ -> None
+    else None
+
+/// Parse a complex array literal `[(r1,i1), (r2,i2), ...]`.
+/// Splits on `), (` pattern so element commas don't confuse the parser.
+let private parseComplexArray (s: string) : (float * float) list option =
+    let t = s.Trim()
+    if t.StartsWith("[") && t.EndsWith("]") then
+        let inner = t.Substring(1, t.Length - 2).Trim()
+        if String.IsNullOrWhiteSpace(inner) then Some []
+        else
+            // Split into element strings. Each element is `(re, im)`.
+            // A simple approach: rebuild parens after splitting.
+            let parts = inner.Split([|"), ("; "),("|], StringSplitOptions.None)
+            let normalized =
+                parts |> Array.mapi (fun i p ->
+                    let withOpen = if i = 0 then p else "(" + p
+                    let withClose = if i = parts.Length - 1 then withOpen else withOpen + ")"
+                    withClose)
+            let parsed = normalized |> Array.map parseComplexPair
+            if parsed |> Array.forall Option.isSome then
+                Some (parsed |> Array.map Option.get |> Array.toList)
+            else None
+    else None
+
+/// Parse a quoted scalar string `"hello"`. Returns the unescaped inner
+/// contents on success. Recognizes \\ and \" escapes (and passes other
+/// backslash sequences through unchanged — matches escapeStringLit's
+/// minimal escape set).
+let private tryParseQuotedString (s: string) : string option =
+    let t = s.Trim()
+    if t.Length >= 2 && t.StartsWith("\"") && t.EndsWith("\"") then
+        let inner = t.Substring(1, t.Length - 2)
+        let sb = System.Text.StringBuilder()
+        let mutable i = 0
+        while i < inner.Length do
+            let c = inner.[i]
+            if c = '\\' && i + 1 < inner.Length then
+                let n = inner.[i + 1]
+                match n with
+                | '"' -> sb.Append('"') |> ignore; i <- i + 2
+                | '\\' -> sb.Append('\\') |> ignore; i <- i + 2
+                | 'n' -> sb.Append('\n') |> ignore; i <- i + 2
+                | 'r' -> sb.Append('\r') |> ignore; i <- i + 2
+                | 't' -> sb.Append('\t') |> ignore; i <- i + 2
+                | _ -> sb.Append(c) |> ignore; i <- i + 1
+            else
+                sb.Append(c) |> ignore
+                i <- i + 1
+        Some (sb.ToString())
+    else None
+
+/// Parse a string-array literal `["a", "b", "c"]`. Walks the inner body
+/// splitting on commas only outside quote regions, so embedded commas
+/// inside string elements (e.g. `["a, b", "c"]`) parse correctly. Returns
+/// None if any element isn't a properly-quoted string.
+let private tryParseStringArray (s: string) : string list option =
+    let t = s.Trim()
+    if t.StartsWith("[") && t.EndsWith("]") then
+        let inner = t.Substring(1, t.Length - 2).Trim()
+        if String.IsNullOrWhiteSpace(inner) then Some []
+        else
+            // Walk inner, splitting at commas that are not inside a quoted region.
+            let elements = ResizeArray<string>()
+            let cur = System.Text.StringBuilder()
+            let mutable inQuotes = false
+            let mutable escaped = false
+            for c in inner do
+                if escaped then
+                    cur.Append(c) |> ignore
+                    escaped <- false
+                elif c = '\\' then
+                    cur.Append(c) |> ignore
+                    escaped <- true
+                elif c = '"' then
+                    cur.Append(c) |> ignore
+                    inQuotes <- not inQuotes
+                elif c = ',' && not inQuotes then
+                    elements.Add(cur.ToString())
+                    cur.Clear() |> ignore
+                else
+                    cur.Append(c) |> ignore
+            if cur.Length > 0 then elements.Add(cur.ToString())
+            let parsed = elements |> Seq.map tryParseQuotedString |> Seq.toList
+            if parsed |> List.forall Option.isSome then
+                Some (parsed |> List.map Option.get)
+            else None
+    else None
+
+/// Does this value text look like a BOOL array pin (`[true, false, ...]`)?
+///
+/// Dispatch in tryParseExpectPin is by leading characters, and `[` alone is
+/// already claimed by the numeric path. Neither `true` nor `false` can begin a
+/// float, a quoted string or a complex pair, so "a `[` whose first element
+/// starts with a boolean literal" is an unambiguous discriminator that cannot
+/// steal `[1, 2]` (numeric), `["a"]` (string) or `[(1,0)]` (complex) from the
+/// branches above it. Deliberately NOT triggered by an empty `[]`: see
+/// tryParseBoolListPin.
+let private looksLikeBoolArray (value: string) : bool =
+    if not (value.StartsWith("[")) then false
+    else
+        let afterBracket = value.Substring(1).TrimStart().ToLowerInvariant()
+        afterBracket.StartsWith("true") || afterBracket.StartsWith("false")
+
+/// Parse a bracketed bool list `[true, false, true]` from the PIN side.
+///
+/// Only the literal spellings `true`/`false` are accepted here (case-
+/// insensitively), exactly as the scalar `ExpectedBool` pin does — a pin is
+/// hand-written, so there is no reason to admit the `1`/`0` spelling and every
+/// reason to keep one canonical way to write it. The tolerance for `1`/`0`
+/// belongs on the ACTUAL side, where the value comes from whatever the
+/// generated printer chose to emit (see tryParse1DBoolArray).
+///
+/// Strict in the same sense as tryParseFloatList: one unparseable element
+/// fails the whole pin, which parseMalformedExpectLines then reports and the
+/// runner turns into a test failure. There is no element-level fallback.
+///
+/// Returns None for an empty `[]` rather than Some []. `[]` carries no
+/// evidence that it is a bool array, and it has always been parsed as an empty
+/// ExpectedArray1D; the two behave identically against an empty printed array
+/// (both only check "zero elements"), so re-routing it here would change which
+/// DU case an existing pin produces for no gain.
+let private tryParseBoolListPin (s: string) : bool list option =
+    let t = s.Trim()
+    if not (t.Length >= 2 && t.StartsWith("[") && t.EndsWith("]")) then None
+    else
+        let inner = t.Substring(1, t.Length - 2).Trim()
+        if String.IsNullOrWhiteSpace(inner) then None
+        else
+            let parsed =
+                splitTopLevelCommas inner
+                |> List.map (fun x ->
+                    match x.Trim().ToLowerInvariant() with
+                    | "true" -> Some true
+                    | "false" -> Some false
+                    | _ -> None)
+            if parsed |> List.forall Option.isSome then Some (parsed |> List.map Option.get)
+            else None
+
+/// Every `// EXPECT:` line of a source, as (verbatim trimmed line, payload)
+/// where the payload is the text after the marker. Both the pin parser and
+/// the malformed-line reporter walk THIS list, so the two can never disagree
+/// about which lines are assertions in the first place.
+let private expectLines (source: string) : (string * string) list =
+    source.Split([|'\n'; '\r'|], StringSplitOptions.RemoveEmptyEntries)
+    |> Array.choose (fun line ->
+        let trimmed = line.Trim()
+        if trimmed.StartsWith("// EXPECT:") then Some (trimmed, trimmed.Substring(10).Trim())
+        else None)
+    |> Array.toList
+
+/// Parse one `// EXPECT:` payload (`varname = value`) into a pin.
+/// None means the line is NOT a usable assertion — either it has no `=` at
+/// all, or its value side failed to parse. Callers must treat None as a
+/// reportable condition (see parseMalformedExpectLines), never as "no pin
+/// here": a dropped pin is an assertion that silently stops being checked.
+let private tryParseExpectPin (payload: string) : ExpectedValue option =
+    match payload.Split([|'='|], 2) with
+    | [| name; value |] ->
+        let name = name.Trim()
+        let value = value.Trim()
+        if name = "" then None
+        elif value.StartsWith("[[") then
+            match tryParse2DList value with
+            | Some rows -> Some (ExpectedArray2D (name, rows))
+            | None -> None
+        elif value.StartsWith("[(") then
+            // Complex array: [(r1,i1), (r2,i2), ...]
+            match parseComplexArray value with
+            | Some pairs -> Some (ExpectedArray1DComplex (name, pairs))
+            | None -> None
+        elif value.StartsWith("[\"") then
+            // String array: ["a", "b", ...]
+            match tryParseStringArray value with
+            | Some xs -> Some (ExpectedArray1DString (name, xs))
+            | None -> None
+        elif looksLikeBoolArray value then
+            // Bool array: [true, false, ...]. Must be tested BEFORE the bare
+            // `[` numeric branch below, which would otherwise swallow it and
+            // fail on Double.TryParse "true". Tested AFTER `[[`, `[(` and `["`
+            // because looksLikeBoolArray only fires on a leading boolean
+            // literal, which none of those three can produce.
+            match tryParseBoolListPin value with
+            | Some bs -> Some (ExpectedArray1DBool (name, bs))
+            | None -> None
+        elif value.StartsWith("[") then
+            match tryParseFloatList value with
+            | Some xs -> Some (ExpectedArray1D (name, xs))
+            | None -> None
+        elif value.StartsWith("(") then
+            // Complex scalar: (re, im)
+            match parseComplexPair value with
+            | Some (re, im) -> Some (ExpectedComplex (name, re, im))
+            | None -> None
+        elif value.StartsWith("\"") then
+            // Scalar string: "..."
+            match tryParseQuotedString value with
+            | Some s -> Some (ExpectedString (name, s))
+            | None -> None
+        elif value.ToLower() = "true" then
+            Some (ExpectedBool (name, true))
+        elif value.ToLower() = "false" then
+            Some (ExpectedBool (name, false))
+        else
+            match Double.TryParse(value) with
+            | true, v -> Some (ExpectedScalar (name, v))
+            | false, _ -> None
+    | _ -> None
 
 /// Parse expected values from test source comments
 /// Format: // EXPECT: varname = value
@@ -28,179 +373,28 @@ type ExpectedValue =
 /// Format: // EXPECT: varname = [(1.0, 0.0), (0.0, 1.0)]          (Complex array)
 /// Format: // EXPECT: varname = "hello"                           (String scalar — quotes required)
 /// Format: // EXPECT: varname = ["a", "b", "c"]                   (String array — quotes around each element)
+/// Format: // EXPECT: varname = [true, false, true]               (Bool array — literal true/false per element)
 let parseExpectedValues (source: string) : ExpectedValue list =
-    let lines = source.Split([|'\n'; '\r'|], StringSplitOptions.RemoveEmptyEntries)
-    
-    let parseFloatList (s: string) : float list =
-        let inner = s.Trim().TrimStart('[').TrimEnd(']').Trim()
-        if String.IsNullOrWhiteSpace(inner) then []
-        else
-            inner.Split(',')
-            |> Array.map (fun x -> 
-                match Double.TryParse(x.Trim()) with
-                | true, v -> v
-                | false, _ -> 0.0)
-            |> Array.toList
-    
-    let parse2DList (s: string) : float list list =
-        // Simple parser for [[a,b],[c,d]] format
-        let inner = s.Trim().TrimStart('[').TrimEnd(']')
-        // Split on "], [" pattern
-        let parts = inner.Split([|"], ["; "],["  |], StringSplitOptions.RemoveEmptyEntries)
-        parts |> Array.map (fun p -> 
-            p.Trim().TrimStart('[').TrimEnd(']').Split(',')
-            |> Array.map (fun x -> 
-                match Double.TryParse(x.Trim()) with
-                | true, v -> v
-                | false, _ -> 0.0)
-            |> Array.toList)
-        |> Array.toList
-    
-    /// Parse a single complex pair `(re, im)` returning (re, im) on success.
-    /// Tolerates surrounding whitespace and accepts both `1` and `1.0` for
-    /// each component (matching the existing Double.TryParse convention).
-    let parseComplexPair (s: string) : (float * float) option =
-        let t = s.Trim()
-        if t.StartsWith("(") && t.EndsWith(")") then
-            let inner = t.Substring(1, t.Length - 2)
-            match inner.Split([|','|], 2) with
-            | [| reStr; imStr |] ->
-                match Double.TryParse(reStr.Trim()), Double.TryParse(imStr.Trim()) with
-                | (true, re), (true, im) -> Some (re, im)
-                | _ -> None
-            | _ -> None
-        else None
-    
-    /// Parse a complex array literal `[(r1,i1), (r2,i2), ...]`.
-    /// Splits on `), (` pattern so element commas don't confuse the parser.
-    let parseComplexArray (s: string) : (float * float) list option =
-        let t = s.Trim()
-        if t.StartsWith("[") && t.EndsWith("]") then
-            let inner = t.Substring(1, t.Length - 2).Trim()
-            if String.IsNullOrWhiteSpace(inner) then Some []
-            else
-                // Split into element strings. Each element is `(re, im)`.
-                // A simple approach: rebuild parens after splitting.
-                let parts = inner.Split([|"), ("; "),("|], StringSplitOptions.None)
-                let normalized =
-                    parts |> Array.mapi (fun i p ->
-                        let withOpen = if i = 0 then p else "(" + p
-                        let withClose = if i = parts.Length - 1 then withOpen else withOpen + ")"
-                        withClose)
-                let parsed = normalized |> Array.map parseComplexPair
-                if parsed |> Array.forall Option.isSome then
-                    Some (parsed |> Array.map Option.get |> Array.toList)
-                else None
-        else None
-    
-    /// Parse a quoted scalar string `"hello"`. Returns the unescaped inner
-    /// contents on success. Recognizes \\ and \" escapes (and passes other
-    /// backslash sequences through unchanged — matches escapeStringLit's
-    /// minimal escape set).
-    let tryParseQuotedString (s: string) : string option =
-        let t = s.Trim()
-        if t.Length >= 2 && t.StartsWith("\"") && t.EndsWith("\"") then
-            let inner = t.Substring(1, t.Length - 2)
-            let sb = System.Text.StringBuilder()
-            let mutable i = 0
-            while i < inner.Length do
-                let c = inner.[i]
-                if c = '\\' && i + 1 < inner.Length then
-                    let n = inner.[i + 1]
-                    match n with
-                    | '"' -> sb.Append('"') |> ignore; i <- i + 2
-                    | '\\' -> sb.Append('\\') |> ignore; i <- i + 2
-                    | 'n' -> sb.Append('\n') |> ignore; i <- i + 2
-                    | 'r' -> sb.Append('\r') |> ignore; i <- i + 2
-                    | 't' -> sb.Append('\t') |> ignore; i <- i + 2
-                    | _ -> sb.Append(c) |> ignore; i <- i + 1
-                else
-                    sb.Append(c) |> ignore
-                    i <- i + 1
-            Some (sb.ToString())
-        else None
+    expectLines source |> List.choose (snd >> tryParseExpectPin)
 
-    /// Parse a string-array literal `["a", "b", "c"]`. Walks the inner body
-    /// splitting on commas only outside quote regions, so embedded commas
-    /// inside string elements (e.g. `["a, b", "c"]`) parse correctly. Returns
-    /// None if any element isn't a properly-quoted string.
-    let tryParseStringArray (s: string) : string list option =
-        let t = s.Trim()
-        if t.StartsWith("[") && t.EndsWith("]") then
-            let inner = t.Substring(1, t.Length - 2).Trim()
-            if String.IsNullOrWhiteSpace(inner) then Some []
-            else
-                // Walk inner, splitting at commas that are not inside a quoted region.
-                let elements = ResizeArray<string>()
-                let cur = System.Text.StringBuilder()
-                let mutable inQuotes = false
-                let mutable escaped = false
-                for c in inner do
-                    if escaped then
-                        cur.Append(c) |> ignore
-                        escaped <- false
-                    elif c = '\\' then
-                        cur.Append(c) |> ignore
-                        escaped <- true
-                    elif c = '"' then
-                        cur.Append(c) |> ignore
-                        inQuotes <- not inQuotes
-                    elif c = ',' && not inQuotes then
-                        elements.Add(cur.ToString())
-                        cur.Clear() |> ignore
-                    else
-                        cur.Append(c) |> ignore
-                if cur.Length > 0 then elements.Add(cur.ToString())
-                let parsed = elements |> Seq.map tryParseQuotedString |> Seq.toList
-                if parsed |> List.forall Option.isSome then
-                    Some (parsed |> List.map Option.get)
-                else None
-        else None
-
-    lines
-    |> Array.choose (fun line ->
-        let trimmed = line.Trim()
-        if trimmed.StartsWith("// EXPECT:") then
-            let rest = trimmed.Substring(10).Trim()
-            match rest.Split([|'='|], 2) with
-            | [| name; value |] ->
-                let name = name.Trim()
-                let value = value.Trim()
-                if value.StartsWith("[[") then
-                    Some (ExpectedArray2D (name, parse2DList value))
-                elif value.StartsWith("[(") then
-                    // Complex array: [(r1,i1), (r2,i2), ...]
-                    match parseComplexArray value with
-                    | Some pairs -> Some (ExpectedArray1DComplex (name, pairs))
-                    | None -> None
-                elif value.StartsWith("[\"") then
-                    // String array: ["a", "b", ...]
-                    match tryParseStringArray value with
-                    | Some xs -> Some (ExpectedArray1DString (name, xs))
-                    | None -> None
-                elif value.StartsWith("[") then
-                    Some (ExpectedArray1D (name, parseFloatList value))
-                elif value.StartsWith("(") then
-                    // Complex scalar: (re, im)
-                    match parseComplexPair value with
-                    | Some (re, im) -> Some (ExpectedComplex (name, re, im))
-                    | None -> None
-                elif value.StartsWith("\"") then
-                    // Scalar string: "..."
-                    match tryParseQuotedString value with
-                    | Some s -> Some (ExpectedString (name, s))
-                    | None -> None
-                elif value.ToLower() = "true" then
-                    Some (ExpectedBool (name, true))
-                elif value.ToLower() = "false" then
-                    Some (ExpectedBool (name, false))
-                else
-                    match Double.TryParse(value) with
-                    | true, v -> Some (ExpectedScalar (name, v))
-                    | false, _ -> None
-            | _ -> None
-        else None)
-    |> Array.toList
+/// The `// EXPECT:` lines that parseExpectedValues could NOT turn into a pin,
+/// returned verbatim so the runner can FAIL the test instead of ignoring the
+/// assertion.
+///
+/// This is the other half of parseExpectedValues, and it exists because
+/// dropping an unparseable pin is silently destructive: a test whose pins ALL
+/// fail to parse reports HasExpectedValues = false, the value gate goes
+/// vacuous, and the test then passes on "compiled and exited 0" alone — the
+/// exact compiles-clean-but-unverified hole EXPECT checks exist to close.
+///
+/// Note this deliberately also reports lines with no `=` (they cannot be
+/// assertions). Some probes use `// EXPECT:` as free prose; deciding which
+/// tests are allowed to do that needs the test NAME, which this function does
+/// not have, so that policy lives in the runner.
+let parseMalformedExpectLines (source: string) : string list =
+    expectLines source
+    |> List.filter (fun (_, payload) -> (tryParseExpectPin payload).IsNone)
+    |> List.map fst
 
 /// Parse the expected-abort message substrings from test source comments.
 /// Format: // ABORT: <substring>   (repeatable — ALL pins must be contained)
@@ -301,6 +495,40 @@ let tryParse1DArray (s: string) : float list option =
             |> Some
     with _ -> None
 
+/// Parse a 1D bool array out of PROGRAM OUTPUT, e.g. "[true, false, true]".
+///
+/// Two spellings are accepted per element, `true`/`false` and `1`/`0`, for the
+/// same reason the scalar ExpectedBool matcher accepts both: whether a printed
+/// Bool reads as a word or a digit depends on whether the generated printer put
+/// `std::boolalpha` on that stream, which is a codegen detail the pin author
+/// cannot see. Anything else is a parse failure, not a silent `false` — a bool
+/// pin that quietly matched garbage would be worse than no pin at all.
+///
+/// Nested rows are flattened: `[[true, false], [true, false]]` parses as four
+/// elements. This mirrors the flat/nested duality already accepted by the
+/// ExpectedArray2D matcher, and it exists because the rank-2 array printers
+/// disagree about whether they emit row brackets. Every element and the total
+/// count are still compared; only the row split is unobservable.
+let rec tryParse1DBoolArray (s: string) : bool list option =
+    let t = s.Trim()
+    if not (t.Length >= 2 && t.StartsWith("[") && t.EndsWith("]")) then None
+    else
+        let inner = t.Substring(1, t.Length - 2).Trim()
+        if String.IsNullOrWhiteSpace(inner) then Some []
+        else
+            let parsed =
+                splitTopLevelCommas inner
+                |> List.map (fun x ->
+                    let e = x.Trim()
+                    if e.StartsWith("[") then tryParse1DBoolArray e
+                    else
+                        match e.ToLowerInvariant() with
+                        | "true" | "1" -> Some [ true ]
+                        | "false" | "0" -> Some [ false ]
+                        | _ -> None)
+            if parsed |> List.forall Option.isSome then Some (parsed |> List.collect Option.get)
+            else None
+
 /// Check if expected values match actual output
 let checkExpectedValues (expected: ExpectedValue list) (output: string) : Result<unit, string list> =
     if expected.IsEmpty then Ok ()
@@ -351,11 +579,88 @@ let checkExpectedValues (expected: ExpectedValue list) (output: string) : Result
                         | Some actualVals -> Some (sprintf "%s: expected %A, got %A" name expectedVals actualVals)
                         | None -> Some (sprintf "%s: could not parse '%s' as array" name actualStr)
                     | None -> Some (sprintf "%s: not found in output" name)
-                    
-                | ExpectedArray2D (name, _) ->
-                    // For now, skip 2D array checking (complex parsing)
-                    None
-                
+
+                | ExpectedArray1DBool (name, expectedVals) ->
+                    // Bools are exact, so there is no tolerance to apply here:
+                    // report the element COUNT first (a length mismatch makes
+                    // per-element diffs meaningless) and then the first
+                    // differing element with its index, matching the shape of
+                    // the numeric-array and complex-array diagnostics.
+                    match actual.TryFind name with
+                    | Some actualStr ->
+                        match tryParse1DBoolArray actualStr with
+                        | Some actualVals ->
+                            if actualVals.Length <> expectedVals.Length then
+                                Some (sprintf "%s: expected %d bool elements, got %d ('%s')"
+                                              name expectedVals.Length actualVals.Length actualStr)
+                            else
+                                List.zip expectedVals actualVals
+                                |> List.mapi (fun i (e, a) -> (i, e, a))
+                                |> List.tryPick (fun (i, e, a) ->
+                                    if e = a then None
+                                    else Some (sprintf "%s: element %d expected %b, got %b" name i e a))
+                        | None -> Some (sprintf "%s: could not parse '%s' as a bool array" name actualStr)
+                    | None -> Some (sprintf "%s: not found in output" name)
+
+                | ExpectedArray2D (name, expectedRows) ->
+                    // Two actual-side shapes are accepted, because the
+                    // generated printers do not all agree:
+                    //
+                    //   nested — `name = [[0, 1], [20, 21]]`. Shape is
+                    //     carried by the output, so rows and per-row lengths
+                    //     are compared before elements.
+                    //   flat   — `name = [0, 1, 20, 21]`. genPrintArrayFlat /
+                    //     genPrintArraySymAware walk a rank-2+ array with
+                    //     nested loops but emit ONE comma-separated run, so
+                    //     the printed text carries no row boundaries. The pin
+                    //     is then compared against its own row-major
+                    //     flattening: every element and the total count are
+                    //     still checked, only the row split is unobservable.
+                    //
+                    // Anything else is a hard error. The previous behaviour —
+                    // returning None for every 2D pin — meant these
+                    // assertions were parsed and then thrown away, so the
+                    // tests carrying them counted as value-check passes
+                    // without a single element ever being compared.
+                    match actual.TryFind name with
+                    | Some actualStr ->
+                        let compareRows (actualRows: float list list) =
+                            if actualRows.Length <> expectedRows.Length then
+                                Some (sprintf "%s: expected %d rows, got %d" name expectedRows.Length actualRows.Length)
+                            else
+                                let rowIssue =
+                                    List.zip expectedRows actualRows
+                                    |> List.mapi (fun i (e, a) -> (i, e, a))
+                                    |> List.tryPick (fun (i, e, a) ->
+                                        if e.Length <> a.Length then
+                                            Some (sprintf "%s: row %d expected %d elements, got %d" name i e.Length a.Length)
+                                        else
+                                            List.zip e a
+                                            |> List.mapi (fun j (ev, av) -> (j, ev, av))
+                                            |> List.tryPick (fun (j, ev, av) ->
+                                                if floatEquals ev av tolerance then None
+                                                else Some (sprintf "%s: [%d][%d] expected %.17g, got %.17g (diff=%.3e)"
+                                                                   name i j ev av (abs (ev - av)))))
+                                rowIssue
+                        match tryParse2DList actualStr with
+                        | Some actualRows -> compareRows actualRows
+                        | None ->
+                            match tryParse1DArray actualStr with
+                            | Some flatActual ->
+                                let flatExpected = List.concat expectedRows
+                                if flatActual.Length <> flatExpected.Length then
+                                    Some (sprintf "%s: expected %d elements (%d rows, row-major), got %d"
+                                                  name flatExpected.Length expectedRows.Length flatActual.Length)
+                                else
+                                    List.zip flatExpected flatActual
+                                    |> List.mapi (fun k (ev, av) -> (k, ev, av))
+                                    |> List.tryPick (fun (k, ev, av) ->
+                                        if floatEquals ev av tolerance then None
+                                        else Some (sprintf "%s: element %d (row-major) expected %.17g, got %.17g (diff=%.3e)"
+                                                           name k ev av (abs (ev - av))))
+                            | None -> Some (sprintf "%s: could not parse '%s' as a 2D array" name actualStr)
+                    | None -> Some (sprintf "%s: not found in output" name)
+
                 | ExpectedComplex (name, expectedRe, expectedIm) ->
                     match actual.TryFind name with
                     | Some actualStr ->

--- a/rewrite/blade-compiler/tests/RunAll.fs
+++ b/rewrite/blade-compiler/tests/RunAll.fs
@@ -2,7 +2,12 @@
 // Extracted from Main.fs (audit §2.3). The OpenMP-coverage and CUDA blocks
 // are OPT-IN here: CUDA needs nvcc + a GPU + (on Windows) cl.exe on PATH —
 // i.e. a run from the "x64 Native Tools Command Prompt for VS" — and the
-// OpenMP block forces multi-threaded runs. Everything else always runs.
+// OpenMP block forces multi-threaded runs. The MPI, timing, interpreter-
+// differential and pinned-oracle blocks are opt-in for the same reason:
+// each needs a resource the build does not produce (mpiexec, a quiet machine,
+// a second full pipeline per test, a pinned ./oracle/Blade.exe).
+// Everything else — including every pure in-process F# unit block — always
+// runs, so the grand total is the whole cheap suite by default.
 module Blade.Tests.RunAll
 
 open Blade.Tests.Basic
@@ -59,17 +64,31 @@ let allTests =
 /// All default to OFF: the CUDA block needs the x64 Native Tools prompt on
 /// Windows, the OpenMP-coverage block forces multi-threaded runs, and the
 /// differential-timing block compiles and repeatedly runs large programs
-/// (it dominates the suite's wall time). Enable with
-/// `blade test --omp --cuda --timing`, or run the blocks standalone
-/// (`blade test omp-coverage`, `blade test cuda`, `blade test timing`).
+/// (it dominates the suite's wall time). The two differential gates are off
+/// for the same reason plus an external-resource one: the interpreter gate
+/// compiles AND interprets the whole supported corpus slice (two full
+/// pipelines per test), and the pinned-oracle gate needs a second Blade build
+/// sitting at ./oracle/Blade.exe that only a release-gating workflow pins.
+/// Enable with `blade test --omp --cuda --timing --mpi --interp --diff-oracle`,
+/// or run the blocks standalone (`blade test omp-coverage`, `blade test cuda`,
+/// `blade test timing`, `blade test mpi`, `blade test interp`,
+/// `blade test diff-oracle`).
 type FullSuiteOptions = {
-    IncludeOmp    : bool
-    IncludeCuda   : bool
-    IncludeTiming : bool
-    IncludeMpi    : bool
+    IncludeOmp        : bool
+    IncludeCuda       : bool
+    IncludeTiming     : bool
+    IncludeMpi        : bool
+    IncludeInterpDiff : bool
+    IncludeDiffOracle : bool
 }
 
-let defaultFullSuiteOptions = { IncludeOmp = false; IncludeCuda = false; IncludeTiming = false; IncludeMpi = false }
+let defaultFullSuiteOptions =
+    { IncludeOmp = false
+      IncludeCuda = false
+      IncludeTiming = false
+      IncludeMpi = false
+      IncludeInterpDiff = false
+      IncludeDiffOracle = false }
 
 /// Includes both the single-file test corpus (`allTests`) and the multi-file
 /// module/import corpus (`multiFileTests`). External-dependency tests
@@ -91,6 +110,24 @@ let runAllTestsFullWith (extraBlocks: (unit -> Blade.Tests.TestHarness.BlockResu
     let attrs = runAttrsTests ()
     // Phase C Step 2: F# unit tests for the codegen substitution mechanism.
     let subst = runCodeGenSubstTests ()
+    // IR-level F# unit tests for the type normalizer (splitting mixed-kind
+    // groups, idempotence, flat-vs-nested equivalence). Constructs IRType
+    // values directly and calls normalize — no Blade source, no C++ toolchain —
+    // so it belongs with the other in-process unit blocks and always runs.
+    // (Also reachable standalone as `blade test normalize`.)
+    let normalize = runNormalizeTests ()
+    // TypeCheck-level F# unit tests for the unify §5.3 fast path: flat-vs-split
+    // arrows, inference-var binding, dist-type ordering/axis-tag rejection.
+    // Same shape as the normalize block — pure IRType construction plus a call
+    // to unify, so it is cheap and unconditional here.
+    // (Also reachable standalone as `blade test unify`.)
+    let unify = runUnifyTests ()
+    // IR-level F# unit tests for the validateArrowShape gate at
+    // mkVirtualArrayArrow entry: which array/arrow shapes the constructor must
+    // refuse. Pure in-process construction, no pipeline, so it runs alongside
+    // the normalize/unify blocks rather than only on demand.
+    // (Also reachable standalone as `blade test validate-arrow`.)
+    let validateArrow = runValidateArrowTests ()
     // Canonical ExprShape traversal: round-trips, walker completeness (§3.2).
     let shape = Blade.Tests.Shape.runShapeTests ()
     // Oracle review: differential-harness oracles vs hand-computed truth (Phase 0.2).
@@ -148,18 +185,47 @@ let runAllTestsFullWith (extraBlocks: (unit -> Blade.Tests.TestHarness.BlockResu
         else
             printfn "Differential timing: not run (opt-in; enable with 'blade test --timing' or run 'blade test timing')."
             None
+    // Interpreter differential gate: the tree-walking IR interpreter vs the
+    // compiled binary over the supported corpus slice, byte-identical
+    // normalized stdout required. Opt-in: it runs BOTH pipelines for every test
+    // in the slice (compile+link+run, then a full interpreter walk), so it
+    // roughly doubles the corpus cost of a suite run. When requested it still
+    // skips cleanly if g++ is absent — the compiled binary is its reference.
+    let interpDiff =
+        if opts.IncludeInterpDiff then
+            Some (Blade.Tests.InterpDiff.runInterpDiffTests Blade.Tests.InterpDiff.currentSlice)
+        else
+            printfn "Interpreter differential: not run (opt-in; enable with 'blade test --interp' or run 'blade test interp')."
+            None
+    // Pinned-oracle differential gate: this binary vs the pinned ./oracle build
+    // over the dense corpus slice, identical printed VALUES required. Opt-in
+    // because it depends on an external resource nothing in the build produces:
+    // a second, previously-gated Blade at ./oracle/Blade.exe. It reports a
+    // clean SKIP (not a failure) when that exe or g++ is missing, so enabling
+    // it on a machine without a pinned oracle is harmless — it is off by
+    // default so a plain `blade test` doesn't spend the corpus twice.
+    let diffOracle =
+        if opts.IncludeDiffOracle then
+            Some (Blade.Tests.DiffOracle.runDiffOracleTests "./oracle/Blade.exe" Blade.Tests.DiffOracle.denseSlice)
+        else
+            printfn "Diff vs pinned oracle: not run (opt-in; enable with 'blade test --diff-oracle' or run 'blade test diff-oracle'; needs a pinned ./oracle/Blade.exe, else it skips)."
+            None
     // Caller-supplied blocks (see doc comment): currently the CLI smoke test.
     let extras = extraBlocks |> List.map (fun run -> run ())
 
     // Grand-total roll-up (#4): one line per block, a total, and failed names.
     let blocks =
-        [ yield r1; yield r2; yield attrs; yield subst; yield shape; yield oracles; yield wigner; yield cartBridge; yield spans; yield diagCore; yield diagCorpus; yield alloc
+        [ yield r1; yield r2; yield attrs; yield subst
+          yield normalize; yield unify; yield validateArrow
+          yield shape; yield oracles; yield wigner; yield cartBridge; yield spans; yield diagCore; yield diagCorpus; yield alloc
           match omp with Some b -> yield b | None -> ()
           yield bufType
           match cuda with Some b -> yield b | None -> ()
           match mpi with Some b -> yield b | None -> ()
           yield diff; yield typeStruct
           match timing with Some b -> yield b | None -> ()
+          match interpDiff with Some b -> yield b | None -> ()
+          match diffOracle with Some b -> yield b | None -> ()
           yield! extras ]
     Blade.Tests.TestHarness.printGrandTotal blocks
     let anyFailed = blocks |> List.sumBy (fun b -> b.Failed)

--- a/rewrite/blade-compiler/tests/Runner.fs
+++ b/rewrite/blade-compiler/tests/Runner.fs
@@ -29,6 +29,18 @@ type FullTestResult = {
     ValueCheckResult: Result<unit, string list>  // Ok() or Error(list of mismatches)
     HasExpectedValues: bool  // Whether the test had EXPECT comments
     AbortExpectation: string list  // "(aborts)" probes: expected output substrings from // ABORT: (all must match)
+    /// "(rejects)" probes: the stage that MUST do the rejecting (// REJECT-AT:).
+    /// Meaningless for non-probes; defaults to RejectAtLower there.
+    RejectStage: RejectStage
+    /// `// EXPECT:` lines that did not parse into a pin and are not excused as
+    /// prose. Non-empty means the test asserts something the harness cannot
+    /// check, which is a failure in its own right (see classifyWithDetail).
+    MalformedExpectLines: string list
+    /// Did the generated C++ actually contain an emitted `#error` guard?
+    /// Captured at generation time (the source text is already in hand there)
+    /// so a codegen-stage reject-probe can be verified without re-reading the
+    /// file later, when it may have been overwritten by a re-run.
+    EmittedErrorGuard: bool
 }
 
 let testLower source =
@@ -81,7 +93,10 @@ type private FsPipelineOutcome =
     | FpIRError of string
     | FpIRValidationError of string list
     | FpIROnly of IRProgram          // compileAndRun = false, no .cpp generated
-    | FpCppGenerated of IRProgram * string * string list * BackendReq  // ir, srcFile, warnings, backend
+    /// ir, srcFile, warnings, backend, emitted-#error-guard. The guard flag is
+    /// read off the generated source HERE, while it is in memory, because a
+    /// codegen-stage reject-probe's verdict depends on it.
+    | FpCppGenerated of IRProgram * string * string list * BackendReq * bool
     | FpGenError of IRProgram * string  // ir was valid but codegen threw
 
 let private runFsharpPipelineLocked (source: string) (testName: string) (outputDir: string) (compileAndRun: bool) : FsPipelineOutcome =
@@ -107,7 +122,12 @@ let private runFsharpPipelineLocked (source: string) (testName: string) (outputD
                         let ext = match backendReq with RequiresCuda -> ".cu" | RequiresMpi | CpuOnly -> ".cpp"
                         let srcFile = Path.Combine(outputDir, safeName + ext)
                         File.WriteAllText(srcFile, cppCode)
-                        FpCppGenerated (ir, srcFile, codegenWarnings, backendReq)
+                        // Codegen emits `#error "Blade codegen: ..."` when it
+                        // deliberately refuses to render a construct. That
+                        // directive — not the mere fact that g++ returned
+                        // nonzero — is what a REJECT-AT: codegen probe pins.
+                        let emittedErrorGuard = cppCode.Contains "#error"
+                        FpCppGenerated (ir, srcFile, codegenWarnings, backendReq, emittedErrorGuard)
                     with ex ->
                         FpGenError (ir, sprintf "Generation failed: %s" ex.Message)
     )
@@ -117,6 +137,24 @@ let runFullTest (testName: string) (source: string) (outputDir: string) (compile
     // Parse expected values from source comments
     let expectedValues = parseExpectedValues source
     let abortExpectation = parseAbortExpectations source
+    let rejectStage = parseRejectStage source
+
+    // Malformed-pin policy. Expect.parseMalformedExpectLines reports EVERY
+    // `// EXPECT:` line it could not turn into a pin, including lines with no
+    // `=` at all — it has no way to know which tests are allowed to write
+    // prose there. The test NAME supplies that: a "(rejects)" probe never
+    // reaches the value-checking stage, so many of them use `// EXPECT:` as
+    // documentation of WHY the program is refused ("typecheck failure —
+    // ragged operands support only ..."). Those lines carry no `=` and are
+    // deliberate, so they are excused. Everything else stands: an `=`-bearing
+    // line that failed to parse is a broken assertion anywhere, and a no-`=`
+    // line on a NORMAL test is an assertion the author believed was being
+    // checked but which had been silently dropped.
+    let malformedExpectLines =
+        let reported = parseMalformedExpectLines source
+        if testName.EndsWith "(rejects)" then
+            reported |> List.filter (fun line -> line.Contains "=")
+        else reported
 
     // F# pipeline (lower + codegen) runs under a lock to avoid cache
     // races. C++ compile and run (below) stay outside the lock so they
@@ -130,26 +168,42 @@ let runFullTest (testName: string) (source: string) (outputDir: string) (compile
         Blade.Runtime.runOnLargeStack (fun () ->
             runFsharpPipelineLocked source testName outputDir compileAndRun)
 
+    // Hoisted so every result-record branch below can record it uniformly:
+    // only the generated-source branch can have seen a `#error` guard, and
+    // "no C++ was produced" must read as "no guard", never as unknown.
+    let emittedErrorGuard =
+        match pipelineOutcome with
+        | FpCppGenerated (_, _, _, _, guard) -> guard
+        | _ -> false
+
     match pipelineOutcome with
     | FpIRError e ->
         { TestName = testName; IRResult = Error e; CppGenerated = false;
           CppFile = None; CompileResult = Error "IR failed"; RunResult = Error "IR failed";
-          ValueCheckResult = Error ["IR failed"]; HasExpectedValues = not expectedValues.IsEmpty; AbortExpectation = abortExpectation }
+          ValueCheckResult = Error ["IR failed"]; HasExpectedValues = not expectedValues.IsEmpty; AbortExpectation = abortExpectation
+          RejectStage = rejectStage; MalformedExpectLines = malformedExpectLines
+          EmittedErrorGuard = emittedErrorGuard }
     | FpIRValidationError validationErrors ->
         for e in validationErrors do printfn "  %s" e
         { TestName = testName; IRResult = Error (validationErrors |> String.concat "; "); CppGenerated = false;
           CppFile = None; CompileResult = Error "IR validation failed"; RunResult = Error "IR validation failed";
-          ValueCheckResult = Error ["IR validation failed"]; HasExpectedValues = not expectedValues.IsEmpty; AbortExpectation = abortExpectation }
+          ValueCheckResult = Error ["IR validation failed"]; HasExpectedValues = not expectedValues.IsEmpty; AbortExpectation = abortExpectation
+          RejectStage = rejectStage; MalformedExpectLines = malformedExpectLines
+          EmittedErrorGuard = emittedErrorGuard }
     | FpIROnly ir ->
         { TestName = testName; IRResult = Ok ir; CppGenerated = false;
           CppFile = None; CompileResult = Error "Skipped"; RunResult = Error "Skipped";
-          ValueCheckResult = Error ["Skipped"]; HasExpectedValues = not expectedValues.IsEmpty; AbortExpectation = abortExpectation }
+          ValueCheckResult = Error ["Skipped"]; HasExpectedValues = not expectedValues.IsEmpty; AbortExpectation = abortExpectation
+          RejectStage = rejectStage; MalformedExpectLines = malformedExpectLines
+          EmittedErrorGuard = emittedErrorGuard }
     | FpGenError (ir, msg) ->
         { TestName = testName; IRResult = Ok ir; CppGenerated = false;
           CppFile = None; CompileResult = Error msg;
           RunResult = Error "Generation failed"; ValueCheckResult = Error ["Generation failed"];
-          HasExpectedValues = not expectedValues.IsEmpty; AbortExpectation = abortExpectation }
-    | FpCppGenerated (ir, srcFile, codegenWarnings, backendReq) ->
+          HasExpectedValues = not expectedValues.IsEmpty; AbortExpectation = abortExpectation
+          RejectStage = rejectStage; MalformedExpectLines = malformedExpectLines
+          EmittedErrorGuard = emittedErrorGuard }
+    | FpCppGenerated (ir, srcFile, codegenWarnings, backendReq, _) ->
         for w in codegenWarnings do
             printfn "  [CodeGen Warning] %s" w
 
@@ -168,7 +222,9 @@ let runFullTest (testName: string) (source: string) (outputDir: string) (compile
             let runErr = if isSkipError e then e else "Compile failed"
             { TestName = testName; IRResult = Ok ir; CppGenerated = true;
               CppFile = Some srcFile; CompileResult = Error e; RunResult = Error runErr;
-              ValueCheckResult = Error [runErr]; HasExpectedValues = not expectedValues.IsEmpty; AbortExpectation = abortExpectation }
+              ValueCheckResult = Error [runErr]; HasExpectedValues = not expectedValues.IsEmpty; AbortExpectation = abortExpectation
+              RejectStage = rejectStage; MalformedExpectLines = malformedExpectLines
+              EmittedErrorGuard = emittedErrorGuard }
         | Ok exeFile ->
             // Step 4: Run — but a CUDA-requiring test on a GPU-less box can
             // compile yet not execute. Validate the compile, skip the run.
@@ -177,7 +233,9 @@ let runFullTest (testName: string) (source: string) (outputDir: string) (compile
                   CppFile = Some srcFile; CompileResult = Ok exeFile;
                   RunResult = Error "Skipped: no GPU";
                   ValueCheckResult = Error ["Skipped: no GPU"];
-                  HasExpectedValues = not expectedValues.IsEmpty; AbortExpectation = abortExpectation }
+                  HasExpectedValues = not expectedValues.IsEmpty; AbortExpectation = abortExpectation
+                  RejectStage = rejectStage; MalformedExpectLines = malformedExpectLines
+                  EmittedErrorGuard = emittedErrorGuard }
             else
                 let runResult = runExecutable exeFile
 
@@ -192,7 +250,9 @@ let runFullTest (testName: string) (source: string) (outputDir: string) (compile
 
                 { TestName = testName; IRResult = Ok ir; CppGenerated = true;
                   CppFile = Some srcFile; CompileResult = Ok exeFile; RunResult = runResult;
-                  ValueCheckResult = valueCheckResult; HasExpectedValues = not expectedValues.IsEmpty; AbortExpectation = abortExpectation }
+                  ValueCheckResult = valueCheckResult; HasExpectedValues = not expectedValues.IsEmpty; AbortExpectation = abortExpectation
+                  RejectStage = rejectStage; MalformedExpectLines = malformedExpectLines
+                  EmittedErrorGuard = emittedErrorGuard }
 
 /// A test whose name ends in "(aborts)" is a runtime-abort probe: the CORRECT
 /// outcome is that it compiles cleanly and then exits nonzero at runtime (a
@@ -212,14 +272,34 @@ let isExpectedAbort (result: FullTestResult) =
         result.AbortExpectation |> List.forall (fun sub -> output.Contains sub)
     | _ -> false
 
-/// Print a full test result
-let printFullTestResult (result: FullTestResult) (verbose: bool) (showFullError: bool) =
+/// Determine if a test result is a full pass
+let isFullPass (result: FullTestResult) =
+    match result.IRResult, result.CompileResult, result.RunResult with
+    | Ok _, Ok _, Ok (0, _) -> true
+    | _ -> false
+
+/// Determine if IR passed (regardless of C++)
+let isIRPass (result: FullTestResult) =
+    match result.IRResult with Ok _ -> true | _ -> false
+
+/// A test whose name ends in "(rejects)" is an intentional reject-probe: the
+/// CORRECT outcome is that the compiler REFUSES it, at the stage pinned by
+/// `// REJECT-AT:` (see Expect.RejectStage). Such a probe counts as PASSING
+/// when it is refused there, and as FAILING when it slips through — which
+/// keeps the grand-total "failed tests" list honest.
+let isRejectProbe (result: FullTestResult) =
+    result.TestName.EndsWith "(rejects)"
+
+/// Per-stage status strings, in pipeline order. "OK" / "FAIL" / "SKIP", plus
+/// "EXIT(n)" for a nonzero run. The value stage is present only when the test
+/// carries pins. Both the verdict and the printed detail read this one list.
+let private stageStatuses (result: FullTestResult) : (string * string) list =
     let irStatus = match result.IRResult with Ok _ -> "OK" | Error _ -> "FAIL"
     let cppStatus = if result.CppGenerated then "OK" else "SKIP"
     let compileStatus = match result.CompileResult with Ok _ -> "OK" | Error e when isSkipError e -> "SKIP" | Error _ -> "FAIL"
-    let runStatus = 
-        match result.RunResult with 
-        | Ok (0, _) -> "OK" 
+    let runStatus =
+        match result.RunResult with
+        | Ok (0, _) -> "OK"
         | Ok (code, _) -> sprintf "EXIT(%d)" code
         | Error e when isSkipError e -> "SKIP"
         | Error _ -> "FAIL"
@@ -229,71 +309,139 @@ let printFullTestResult (result: FullTestResult) (verbose: bool) (showFullError:
              | Ok () -> "OK"
              | Error errs when errs |> List.exists isSkipError -> "SKIP"
              | Error _ -> "FAIL"
-    
-    // Fold the per-stage statuses into a single standardized result line.
-    // Overall outcome: FAIL if any stage failed; SKIP if a stage skipped (and
-    // none failed); otherwise PASS. The detail differs by outcome:
-    //   PASS -> the list of stages that actually ran, e.g. "(IR,Gen,Compile,Run,Val)"
-    //   FAIL -> the first failing stage and its kind, e.g. "Compile failed"
-    //   SKIP -> the skipped stage, e.g. "Compile skipped"
-    let stages =
-        [ "IR", irStatus
-          "Gen", cppStatus
-          "Compile", compileStatus
-          "Run", runStatus ]
-        @ (if valueStatus = "" then [] else [ "Val", valueStatus ])
+    [ "IR", irStatus
+      "Gen", cppStatus
+      "Compile", compileStatus
+      "Run", runStatus ]
+    @ (if valueStatus = "" then [] else [ "Val", valueStatus ])
+
+/// THE verdict. This is the ONLY place a test's outcome is decided: the
+/// per-test `[PASS]/[FAIL]/[SKIP]` line and the block roll-up both call it,
+/// so the line and the totals cannot drift apart. (They did: a skipped
+/// reject-probe printed [FAIL] while the roll-up counted it as a pass,
+/// because the printer folded stage statuses and the roll-up ran a separate
+/// `isCorrectOutcome` predicate.) Returns the outcome plus the human-readable
+/// detail that explains it, so the explanation is derived from the same
+/// decision rather than recomputed alongside it.
+///
+/// Rules, in priority order:
+///
+///  1. A malformed `// EXPECT:` line fails the test outright, whatever else
+///     happened. The test asserts something the harness cannot evaluate; the
+///     old behaviour (drop the pin) turned a broken assertion into no
+///     assertion, and the test then passed on "compiled and exited 0" alone.
+///
+///  2. A SKIP is never a pass — for probes as much as for normal tests. This
+///     is what closes the reject-probe hole: the old rule credited a probe
+///     that failed for ANY reason, so on a box where the toolchain was down
+///     every one of the 150 probes reported green while `Compiled: 0 / 921`.
+///
+///  3. A reject-probe is judged at the stage it pins, not on "did anything go
+///     wrong". REJECT-AT: lower must be refused by parse/typecheck/lowering.
+///     REJECT-AT: codegen must lower cleanly, emit a `#error` guard into the
+///     generated source, and then fail the C++ compile — verifying the guard
+///     is the whole point, since it is what distinguishes "our deliberate
+///     refusal fired" from "we emitted garbage C++" and from "g++ is broken".
+///
+///  4. An abort-probe must compile, run, and exit nonzero with its pinned
+///     `// ABORT:` message (isExpectedAbort).
+///
+///  5. A normal test must be a full pass and, when it carries pins, must pass
+///     the value check. Compiles-clean-but-prints-the-wrong-numbers is a
+///     failure; that class is the entire reason EXPECT checks exist.
+let classifyWithDetail (result: FullTestResult) : Blade.Tests.TestHarness.Outcome * string =
+    let stages = stageStatuses result
     let anyFail = stages |> List.exists (fun (_, s) -> s = "FAIL" || s.StartsWith "EXIT")
     let anySkip = stages |> List.exists (fun (_, s) -> s = "SKIP")
-    // A reject-probe (name ends in "(rejects)") is SUPPOSED to fail. If it
-    // does, that's a pass; if it unexpectedly succeeds, that's the failure.
-    let isReject = result.TestName.EndsWith "(rejects)"
-    // An abort-probe (name ends in "(aborts)") is SUPPOSED to compile and
-    // then exit nonzero at runtime, with the pinned // ABORT: message.
-    let isAbort = isAbortProbe result
-    let outcome =
-        if isReject then
-            if anyFail then Blade.Tests.TestHarness.Pass    // correctly rejected
-            else Blade.Tests.TestHarness.Fail               // should have been rejected
-        elif isAbort then
-            if isExpectedAbort result then Blade.Tests.TestHarness.Pass
-            elif anySkip && not anyFail then Blade.Tests.TestHarness.Skip
-            else Blade.Tests.TestHarness.Fail
-        elif anyFail then Blade.Tests.TestHarness.Fail
-        elif anySkip then Blade.Tests.TestHarness.Skip
-        else Blade.Tests.TestHarness.Pass
-    let detail =
-        if isReject then
-            if anyFail then
-                let (stg, _) = stages |> List.find (fun (_, s) -> s = "FAIL" || s.StartsWith "EXIT")
-                sprintf "correctly rejected at %s" stg
-            else "expected rejection but it was accepted"
-        elif isAbort then
-            match result.RunResult with
-            | Ok (code, output) when code <> 0 ->
-                match result.AbortExpectation |> List.tryFind (fun sub -> not (output.Contains sub)) with
-                | Some sub ->
-                    sprintf "aborted (exit %d) but output lacks '%s'" code sub
-                | None -> sprintf "aborted as expected (exit %d)" code
-            | Ok (0, _) -> "expected runtime abort but exited 0"
-            | _ ->
-                match stages |> List.tryFind (fun (_, s) -> s = "FAIL" || s = "SKIP") with
-                | Some (stg, "SKIP") -> sprintf "%s skipped" stg
-                | Some (stg, _) -> sprintf "expected runtime abort but %s failed" stg
-                | None -> "expected runtime abort"
+    let compileSkipped =
+        match result.CompileResult with Error e when isSkipError e -> true | _ -> false
+
+    if not result.MalformedExpectLines.IsEmpty then
+        Blade.Tests.TestHarness.Fail,
+        sprintf "unparseable EXPECT pin(s): %s"
+            (result.MalformedExpectLines |> String.concat " | ")
+
+    elif isRejectProbe result then
+        match result.RejectStage with
+        | RejectAtLower ->
+            match result.IRResult with
+            | Error _ -> Blade.Tests.TestHarness.Pass, "correctly rejected during lowering"
+            | Ok _ ->
+                Blade.Tests.TestHarness.Fail,
+                "expected rejection during lowering, but the program lowered"
+        | RejectAtCodegen ->
+            match result.IRResult with
+            | Error _ ->
+                // Mis-pinned corpus entry (or a checker improvement that moved
+                // the rejection earlier). Either way the pin no longer
+                // describes reality, so say so instead of quietly passing.
+                Blade.Tests.TestHarness.Fail,
+                "pinned REJECT-AT: codegen but lowering rejected it -- re-pin as 'lower'"
+            | Ok _ ->
+                if not result.CppGenerated then
+                    // No source at all: either the pipeline was run IR-only
+                    // (no toolchain) or codegen threw. The first is a skip,
+                    // the second a failure — a codegen CRASH is not the
+                    // deliberate `#error` guard this probe pins.
+                    if compileSkipped then
+                        Blade.Tests.TestHarness.Skip, "codegen-stage probe: no C++ generated (toolchain unavailable)"
+                    else
+                        Blade.Tests.TestHarness.Fail, "expected an emitted #error guard, but codegen produced no source"
+                elif not result.EmittedErrorGuard then
+                    Blade.Tests.TestHarness.Fail,
+                    "expected an emitted #error guard, but the generated C++ contains none"
+                else
+                    match result.CompileResult with
+                    | Error e when isSkipError e ->
+                        Blade.Tests.TestHarness.Skip, "#error guard emitted but not compiled (toolchain unavailable)"
+                    | Error _ ->
+                        Blade.Tests.TestHarness.Pass, "correctly rejected by the emitted #error guard"
+                    | Ok _ ->
+                        Blade.Tests.TestHarness.Fail,
+                        "#error guard emitted but the C++ compiled anyway"
+
+    elif isAbortProbe result then
+        if isExpectedAbort result then
+            let code = match result.RunResult with Ok (c, _) -> c | _ -> 0
+            Blade.Tests.TestHarness.Pass, sprintf "aborted as expected (exit %d)" code
         else
-            match outcome with
-            | Blade.Tests.TestHarness.Pass ->
-                // One-liner for passes (#3): the stages that ran, as the detail.
-                sprintf "(%s)" (stages |> List.map fst |> String.concat ",")
-            | Blade.Tests.TestHarness.Fail ->
-                let (stg, st) = stages |> List.find (fun (_, s) -> s = "FAIL" || s.StartsWith "EXIT")
-                if st.StartsWith "EXIT" then sprintf "%s %s" stg st
-                else sprintf "%s failed" stg
-            | Blade.Tests.TestHarness.Skip ->
-                let (stg, _) = stages |> List.find (fun (_, s) -> s = "SKIP")
-                sprintf "%s skipped" stg
+            let detail =
+                match result.RunResult with
+                | Ok (code, output) when code <> 0 ->
+                    match result.AbortExpectation |> List.tryFind (fun sub -> not (output.Contains sub)) with
+                    | Some sub -> sprintf "aborted (exit %d) but output lacks '%s'" code sub
+                    | None -> sprintf "aborted as expected (exit %d)" code
+                | Ok (0, _) -> "expected runtime abort but exited 0"
+                | _ ->
+                    match stages |> List.tryFind (fun (_, s) -> s = "FAIL" || s = "SKIP") with
+                    | Some (stg, "SKIP") -> sprintf "%s skipped" stg
+                    | Some (stg, _) -> sprintf "expected runtime abort but %s failed" stg
+                    | None -> "expected runtime abort"
+            if anySkip && not anyFail then Blade.Tests.TestHarness.Skip, detail
+            else Blade.Tests.TestHarness.Fail, detail
+
+    elif anyFail then
+        let (stg, st) = stages |> List.find (fun (_, s) -> s = "FAIL" || s.StartsWith "EXIT")
+        let detail = if st.StartsWith "EXIT" then sprintf "%s %s" stg st else sprintf "%s failed" stg
+        Blade.Tests.TestHarness.Fail, detail
+    elif anySkip then
+        let (stg, _) = stages |> List.find (fun (_, s) -> s = "SKIP")
+        Blade.Tests.TestHarness.Skip, sprintf "%s skipped" stg
+    else
+        // One-liner for passes (#3): the stages that ran, as the detail.
+        Blade.Tests.TestHarness.Pass,
+        sprintf "(%s)" (stages |> List.map fst |> String.concat ",")
+
+/// The verdict alone. Everything that needs to bucket a result — the roll-up,
+/// the summary counters — goes through here, never through an ad-hoc predicate.
+let classify (result: FullTestResult) : Blade.Tests.TestHarness.Outcome =
+    fst (classifyWithDetail result)
+
+/// Print a full test result
+let printFullTestResult (result: FullTestResult) (verbose: bool) (showFullError: bool) =
+    let (outcome, detail) = classifyWithDetail result
     Blade.Tests.TestHarness.resultLine outcome result.TestName detail
-    
+
     if verbose then
         match result.IRResult with
         | Error e -> printfn "    IR Error: %s" e
@@ -329,41 +477,12 @@ let printFullTestResult (result: FullTestResult) (verbose: bool) (showFullError:
                 printfn "    Value Error: %s" err
         | _ -> ()
 
-/// Determine if a test result is a full pass
-let isFullPass (result: FullTestResult) =
-    match result.IRResult, result.CompileResult, result.RunResult with
-    | Ok _, Ok _, Ok (0, _) -> true
-    | _ -> false
-
-/// Determine if IR passed (regardless of C++)
-let isIRPass (result: FullTestResult) =
-    match result.IRResult with Ok _ -> true | _ -> false
-
-/// A test whose name ends in "(rejects)" is an intentional reject-probe: the
-/// CORRECT outcome is that it fails IR (or otherwise refuses to compile). We
-/// treat such a test as PASSING when it does fail, and as FAILING only if it
-/// unexpectedly slips through. This keeps the grand-total "failed tests" list
-/// honest — intentional rejects that behave correctly are not failures.
-let isRejectProbe (result: FullTestResult) =
-    result.TestName.EndsWith "(rejects)"
-
-/// Did the test behave correctly? For a reject-probe: correctly NOT passing
-/// (it was supposed to be rejected). For a normal test: a full pass AND — when
-/// the test carries EXPECT values — a passing value check. A program that
-/// compiles, runs, and prints the WRONG values is a FAILURE: the
-/// compiles-clean-but-wrong class is the entire reason EXPECT checks exist.
-/// Before this gate, value mismatches surfaced only in the informational
-/// "Value Check: N/M" summary line while the block total stayed green — a
-/// known-red value test (functions/001, pinning the refuted shared-index-space
-/// symmetry rule) rode inside "TOTAL: 0 failed" undetected until the arc-1
-/// correction surfaced it.
+/// Did the test behave correctly? A thin alias over `classify` so there is
+/// exactly one definition of "correct" in the harness. Note a SKIP is not
+/// correct and not incorrect — callers that care must ask `classify` directly
+/// rather than reading `not (isCorrectOutcome r)` as "failed".
 let isCorrectOutcome (result: FullTestResult) =
-    if isRejectProbe result then not (isFullPass result)
-    elif isAbortProbe result then isExpectedAbort result
-    else
-        isFullPass result &&
-        (not result.HasExpectedValues ||
-         (match result.ValueCheckResult with Ok () -> true | Error _ -> false))
+    classify result = Blade.Tests.TestHarness.Pass
 
 /// Run test category with IR only
 let runTestCategory name tests =
@@ -481,7 +600,17 @@ let runMultiFileTestsFull (name: string) (tests: (string * (string * string) lis
                             // Parse expected values from the LAST source (Main module)
                             let mainSource = sources |> List.last |> snd
                             let expectedValues = parseExpectedValues mainSource
-                            if expectedValues.IsEmpty then
+                            // Same rule as the single-file runner: a pin that
+                            // does not parse is a failure, not a silently
+                            // skipped assertion. No multi-file test is a probe,
+                            // so there is no prose exemption to apply here.
+                            let malformed = parseMalformedExpectLines mainSource
+                            if not malformed.IsEmpty then
+                                Blade.Tests.TestHarness.resultLine Blade.Tests.TestHarness.Fail testName
+                                    (sprintf "unparseable EXPECT pin(s): %s" (String.concat " | " malformed))
+                                failed <- failed + 1
+                                failedNames <- failedNames @ [testName]
+                            elif expectedValues.IsEmpty then
                                 Blade.Tests.TestHarness.resultLine Blade.Tests.TestHarness.Pass testName "no EXPECT"
                                 passed <- passed + 1
                             else
@@ -605,20 +734,45 @@ let runTestCategoryFull (name: string) (tests: (string * string) list) (outputDi
         | None -> ()
     | None -> ()
     
-    // Summary
+    // Summary.
+    //
+    // Every count below is derived from ONE classification pass, so no line of
+    // this block can contradict another or contradict the grand total. The
+    // summary used to print "IR Lowering: 775 passed, 146 failed" for a run
+    // whose grand total said "0 failed", with nothing to explain that the 146
+    // were deliberate rejections — two true numbers that could not be
+    // reconciled by a reader. The probe population is now stated outright and
+    // the IR line says which rejections were expected.
+    let verdicts = results |> List.map (fun r -> r, classify r)
+    let countWhere pred = verdicts |> List.filter (snd >> pred) |> List.length
+    let passed  = countWhere (fun v -> v = Blade.Tests.TestHarness.Pass)
+    let failed  = countWhere (fun v -> v = Blade.Tests.TestHarness.Fail)
+    let skipped = countWhere (fun v -> v = Blade.Tests.TestHarness.Skip)
+    let failedResults = verdicts |> List.filter (fun (_, v) -> v = Blade.Tests.TestHarness.Fail) |> List.map fst
+    let isSkippedVerdict (r: FullTestResult) = classify r = Blade.Tests.TestHarness.Skip
+
     let irPassed = results |> List.filter isIRPass |> List.length
     let irFailed = results.Length - irPassed
     let fullPassed = results |> List.filter isFullPass |> List.length
     let compiled = results |> List.filter (fun r -> match r.CompileResult with Ok _ -> true | _ -> false) |> List.length
     let generated = results |> List.filter (fun r -> r.CppGenerated) |> List.length
 
-    // A test is "skipped" if either its compile or its run was skipped
-    // (no toolchain, or no GPU for a CUDA-requiring test). Skips are not
-    // failures and must not deflate the pass totals.
-    let isSkipped (r: FullTestResult) =
-        (match r.CompileResult with Error e when isSkipError e -> true | _ -> false) ||
-        (match r.RunResult with Error e when isSkipError e -> true | _ -> false)
-    let skipped = results |> List.filter isSkipped |> List.length
+    // Probe population. A reject-probe that lowers is NOT counted as an
+    // expected rejection here — only one that actually got refused at the
+    // stage it pins, which is exactly the classifier's Pass condition for a
+    // RejectAtLower probe.
+    let rejectProbes = results |> List.filter isRejectProbe
+    let abortProbes = results |> List.filter isAbortProbe
+    let rejectAtLower = rejectProbes |> List.filter (fun r -> r.RejectStage = RejectAtLower)
+    let rejectAtCodegen = rejectProbes |> List.filter (fun r -> r.RejectStage = RejectAtCodegen)
+    let expectedIrRejections =
+        rejectAtLower |> List.filter (fun r -> not (isIRPass r)) |> List.length
+    let unexpectedIrFailures = irFailed - expectedIrRejections
+
+    // Tests carrying an EXPECT line the harness could not parse. Reported so
+    // a corpus authoring error is visible as such rather than as a mysterious
+    // failure in an unrelated stage.
+    let malformedPinTests = results |> List.filter (fun r -> not r.MalformedExpectLines.IsEmpty) |> List.length
 
     // Tests whose codegen inferred the CUDA backend (emitted device
     // kernels → .cu source). Reported separately so the CPU/CUDA split
@@ -626,40 +780,42 @@ let runTestCategoryFull (name: string) (tests: (string * string) list) (outputDi
     let cudaTests =
         results |> List.filter (fun r ->
             match r.CppFile with Some f -> f.EndsWith(".cu") | None -> false) |> List.length
-    
+
     // Count value check results (only for tests that have expected values
     // AND weren't skipped — a skipped test has no output to check).
-    let testsWithExpected = results |> List.filter (fun r -> r.HasExpectedValues && not (isSkipped r))
-    let valuesPassed = testsWithExpected |> List.filter (fun r -> 
+    let testsWithExpected = results |> List.filter (fun r -> r.HasExpectedValues && not (isSkippedVerdict r))
+    let valuesPassed = testsWithExpected |> List.filter (fun r ->
         match r.ValueCheckResult with Ok () -> true | _ -> false) |> List.length
 
     let caps = capabilities.Value
     let platformStr = match caps.Platform with PWindows -> "Windows" | PLinux -> "Linux" | PMacOS -> "macOS"
-    
+
     printHeader "Test Summary"
     printfn "Environment:  %s | g++:%b nvcc:%b cl:%b gpu:%b"
         platformStr caps.HasGpp caps.HasNvcc caps.HasCl caps.HasGpu
-    printfn "IR Lowering:  %d passed, %d failed" irPassed irFailed
+    printfn "IR Lowering:  %d lowered, %d rejected (%d expected, %d unexpected)"
+        irPassed irFailed expectedIrRejections unexpectedIrFailures
+    if not rejectProbes.IsEmpty || not abortProbes.IsEmpty then
+        printfn "Probes:       %d reject (%d lower, %d codegen), %d abort"
+            rejectProbes.Length rejectAtLower.Length rejectAtCodegen.Length abortProbes.Length
     printfn "C++ Generated: %d / %d  (CUDA backend: %d)" generated results.Length cudaTests
     if gppAvailable then
         printfn "Compiled:     %d / %d" compiled results.Length
         printfn "Full Pass:    %d / %d (IR + Compile + Run)" fullPassed results.Length
-        if skipped > 0 then
-            printfn "Skipped:      %d (toolchain/GPU unavailable)" skipped
         if testsWithExpected.Length > 0 then
             printfn "Value Check:  %d / %d" valuesPassed testsWithExpected.Length
     else
         printfn "Generated files in: %s" (Path.GetFullPath outputDir)
+    if malformedPinTests > 0 then
+        printfn "Bad EXPECT:   %d test(s) with an unparseable pin (counted as failures)" malformedPinTests
+    // The block's own verdict line — the same three numbers this block
+    // contributes to the grand total, so the two are checkable by eye.
+    printfn "Verdict:      %d passed, %d failed, %d skipped" passed failed skipped
     printfn "Total Tests:  %d" results.Length
 
-    // Build the BlockResult for the grand-total roll-up using reject-aware
-    // classification: a "(rejects)" probe that correctly fails counts as a
-    // pass; only genuinely-wrong outcomes are failures and appear in the list.
-    // Skipped tests (no toolchain/GPU) are neither.
-    let nonSkipped = results |> List.filter (fun r -> not (isSkipped r))
-    let correctResults = nonSkipped |> List.filter isCorrectOutcome
-    let failedResults  = nonSkipped |> List.filter (fun r -> not (isCorrectOutcome r))
-    { Block = name; Passed = correctResults.Length; Failed = failedResults.Length;
+    // The BlockResult IS the verdict tally: same classifier, same numbers as
+    // the "Verdict:" line above and as every per-test [PASS]/[FAIL]/[SKIP].
+    { Block = name; Passed = passed; Failed = failed;
       Skipped = skipped; FailedNames = failedResults |> List.map (fun r -> r.TestName) }
 
 /// Run tests with C++ generation only (no compilation)

--- a/rewrite/blade-compiler/tests/TestHarness.fs
+++ b/rewrite/blade-compiler/tests/TestHarness.fs
@@ -105,6 +105,10 @@ type BlockResult =
       Skipped: int
       FailedNames: string list }
 
+/// How many failed-test names the grand-total roll-up lists before summarizing
+/// the rest as a count. One constant so the cap is tunable in one place.
+let failedRollUpCap = 40
+
 /// Print the final grand-total report across all blocks.
 let printGrandTotal (blocks: BlockResult list) =
     let rule = String.replicate ruleWidth "="
@@ -124,9 +128,18 @@ let printGrandTotal (blocks: BlockResult list) =
     printfn "%s" (String.replicate ruleWidth "-")
     let skipTotal = if totalSkipped > 0 then sprintf ", %d skipped" totalSkipped else ""
     printfn "  TOTAL: %d passed, %d failed%s" totalPassed totalFailed skipTotal
-    // Failed-test roll-up.
+    // Failed-test roll-up. Capped: this is an INDEX into the per-block output
+    // above (every failure already printed its own "[FAIL]: ..." line with the
+    // detail), not the report of record. A broad regression can fail hundreds
+    // of corpus tests at once, and an unbounded list scrolls the TOTAL line —
+    // the one line a reader checks — off the screen, which is exactly how a red
+    // run gets misread as green. Show the first `failedRollUpCap` and say how
+    // many more there are.
     let allFailed = blocks |> List.collect (fun b -> b.FailedNames |> List.map (fun n -> b.Block, n))
     if not allFailed.IsEmpty then
         printfn "\n  Failed tests:"
-        for (blk, nm) in allFailed do
+        for (blk, nm) in allFailed |> List.truncate failedRollUpCap do
             printfn "    [%s] %s" blk nm
+        let hidden = allFailed.Length - failedRollUpCap
+        if hidden > 0 then
+            printfn "    ... and %d more (see the per-block [FAIL] lines above)" hidden

--- a/rewrite/blade-compiler/tests/corpus/basic/010_cons_destructure.blade
+++ b/rewrite/blade-compiler/tests/corpus/basic/010_cons_destructure.blade
@@ -2,3 +2,12 @@
 // :: destructuring pattern
 let t = (1, 2, 3)
 let head :: tail = t
+// head binds tuple element 0; tail binds the REMAINDER — the 2-tuple (2, 3),
+// NOT element 1. (It used to bind element 1, and both names came out Float64
+// because the checker gave every cons leaf a fresh, unconstrained type var.)
+// Tuple-typed bindings are not auto-printed (std::tuple has no operator<<),
+// so tail is re-destructured to pin its contents element by element.
+let (t0, t1) = tail
+// EXPECT: head = 1
+// EXPECT: t0 = 2
+// EXPECT: t1 = 3

--- a/rewrite/blade-compiler/tests/corpus/basic/021_cons_destructure_block.blade
+++ b/rewrite/blade-compiler/tests/corpus/basic/021_cons_destructure_block.blade
@@ -1,0 +1,18 @@
+// TEST: Cons Destructure In Block
+// Block-scoped `let head :: tail = t`. inferBlock's TStmtLet handling used to
+// record SubBindings for PatTuple ONLY, so a cons pattern inside a block bound
+// nothing at all and both names surfaced later as UnboundVariable. Semantics
+// are identical to the top-level form (010_cons_destructure): head is element
+// 0 and tail is the REMAINDER — the 2-tuple (2, 3), not element 1.
+// Block-local names are never auto-printed (only module-level bindings are),
+// and a tuple-typed binding prints nothing in any case, so the block returns a
+// digit-weighted scalar that pins all three leaves at once.
+let result = {
+    let t = (1, 2, 3)
+    let head :: tail = t
+    let (t0, t1) = tail
+    head * 100 + t0 * 10 + t1
+}
+// head = 1, tail = (2, 3), so t0 = 2 and t1 = 3.
+// 1*100 + 2*10 + 3 = 123.
+// EXPECT: result = 123

--- a/rewrite/blade-compiler/tests/corpus/basic/022_cons_destructure_expr_position.blade
+++ b/rewrite/blade-compiler/tests/corpus/basic/022_cons_destructure_expr_position.blade
@@ -1,0 +1,17 @@
+// TEST: Cons Destructure In Expression Position
+// A `let` written where an EXPRESSION is expected (here, the RHS of another
+// let) parses as ExprLet, not StmtLet. Blade has no `let ... in`, so
+// Parser.parseLet gives that form a synthesized UNIT body — the leaves are
+// consequently dead, and nothing observable can be pinned on them. What this
+// probe pins is that the form type-checks and lowers at all: the checker used
+// to give every cons leaf a fresh type variable and emit a single TExprLet
+// whose varId bound NONE of the leaves, so a leaf reference lowered to an IRId
+// that nothing introduces. It now desugars to a nested chain of TExprLets (one
+// temp for the scrutinee, one let per leaf), and `after` proves the rest of
+// the program still compiles and runs around it.
+let t = (1, 2, 3)
+let probe = let head :: tail = t
+let after = 7
+// `probe` is Unit-typed (the synthesized body is the unit literal) and Unit
+// bindings are not auto-printed, so only `after` can be pinned.
+// EXPECT: after = 7

--- a/rewrite/blade-compiler/tests/corpus/basic/023_cons_non_tuple_scrutinee_rejects.blade
+++ b/rewrite/blade-compiler/tests/corpus/basic/023_cons_non_tuple_scrutinee_rejects.blade
@@ -1,0 +1,12 @@
+// TEST: Cons Non-Tuple Scrutinee (rejects)
+// `head :: tail` splits a TUPLE into leading elements plus a non-empty
+// remainder. A scalar scrutinee has nothing to split, so the checker reports
+// PatternTypeMismatch (BL3004) instead of binding both names to fresh,
+// unconstrained type variables. That silent shape is the original defect:
+// unconstrained leaf vars zonked to the default Float64 while Lowering
+// projected positionally, so `tail` bound element 1 of whatever it found.
+// `s` is defined so the ONLY failure reason is the unsplittable pattern (not
+// an undefined name).
+let s = 5
+let head :: tail = s
+// EXPECT: typecheck failure — `head :: tail` requires a tuple scrutinee.

--- a/rewrite/blade-compiler/tests/corpus/basic/024_flat_tuple_destructure_expr_position.blade
+++ b/rewrite/blade-compiler/tests/corpus/basic/024_flat_tuple_destructure_expr_position.blade
@@ -1,0 +1,52 @@
+// TEST: Flat Tuple Destructure In Expression Position
+// A `let` written where an EXPRESSION is expected (here, the RHS of another
+// let) parses as ExprLet, not StmtLet. Blade has no `let ... in`, so
+// Parser.parseLet gives that form a synthesized UNIT body — its leaves are
+// dead, and NOTHING about their values can be observed at run time. Same hard
+// constraint as 022_cons_destructure_expr_position; see the honest accounting
+// of what is and is not asserted at the bottom of this file.
+//
+// The gap this probe covers: `(a, b, c)` against ((Int, Int), Int) is a FLAT
+// match — three names against TWO structural slots. Expression position used
+// to desugar the STRUCTURAL shape only and drop a flat pattern into the
+// value-only fallback, which binds no leaf at all, so a, b and c would surface
+// later as UnboundVariable. It now emits one let per FLAT leaf, each reached by
+// a PATH of ordinary tuple projections:
+//     a = get<0>(get<0>(y))   b = get<1>(get<0>(y))   c = get<1>(y)
+// which is what a flat projection means, and is the same leaf order
+// IR.flattenTupleLeaves hands the declaration-position path.
+let x = (1, 2)
+let y = (x, 3)
+let probe = let (a, b, c) = y
+
+// The DECLARATION-position flat destructure of the very same scrutinee, pinned
+// by value. This is the order contract the expression-position desugar above
+// must agree with (and the only side of it that a running program can see):
+// y is ((1, 2), 3), whose flat leaves left-to-right are 1, 2, 3, so a three-name
+// pattern takes them in that order. Scalar-tuple mirror of
+// tuple-views/004_tuple_view_scalar_flat, kept here so this file states the
+// contract it is about in one place.
+let (d, e, f) = y
+// EXPECT: d = 1
+// EXPECT: e = 2
+// EXPECT: f = 3
+
+let after = 7
+// EXPECT: after = 7
+
+// WHAT THIS FILE ASSERTS, precisely:
+//   * d/e/f pin flat leaf ORDER for the shape ((1, 2), 3) — really checked.
+//   * `after` pins that the expression-position flat destructure above did not
+//     break the program: it type-checks, lowers, emits and runs, and the
+//     bindings around it are untouched. The desugar now emits CHAINED
+//     projections (get<_>(get<_>(...))) where it previously emitted none; an
+//     intermediate node carrying the wrong type would fall off Lowering's
+//     static IRTupleProj arm onto the poly-pack path instead, so this is a real
+//     guard on new code even though the leaves themselves are dead.
+//   * It does NOT assert the values of a, b, c. It CANNOT: the synthesized unit
+//     body has no reference to them, so both the old (bind nothing) and the new
+//     (bind three leaves) behaviour produce a program that runs identically.
+//     Nothing short of a `let ... in` form, or a block-scoped let (see
+//     021_cons_destructure_block for that variant), can observe them.
+//   * `probe` is Unit-typed — the synthesized body is the unit literal — and
+//     Unit bindings are not auto-printed, so it cannot be pinned either.

--- a/rewrite/blade-compiler/tests/corpus/basic/025_struct_destructure_block.blade
+++ b/rewrite/blade-compiler/tests/corpus/basic/025_struct_destructure_block.blade
@@ -1,0 +1,36 @@
+// TEST: Struct Destructure In Block
+// Block-scoped `let Point { x, y } = p`. inferBlock's TStmtLet handling used to
+// record SubBindings for PatTuple and PatCons ONLY, so a struct pattern inside a
+// block bound nothing at all and both field names surfaced later in the block as
+// UnboundVariable. Semantics are identical to the top-level form
+// (structs/003_struct_pattern): each leaf takes the field of its OWN name.
+//
+// The second block is the by-name probe. Projection is BY NAME, never by
+// position — Lowering emits IRFieldAccess keyed on the leaf's own name, and the
+// checker now reads the leaf's declared TYPE the same way (structFieldTypesOf,
+// shared with checkDecl's DeclLet arm). `swapped` writes the two fields in the
+// OPPOSITE order from the declaration and must still bind x to field `x` and y
+// to field `y`; a positional rule would shear them past each other.
+//
+// Block-local names are never auto-printed (only module-level bindings are), and
+// a struct-typed binding prints nothing in any case (genPrintStatements has an
+// `IRTNamed _ -> []` arm), so each block returns a digit-weighted scalar that
+// pins both leaves at once.
+struct Point {
+    x: Int,
+    y: Int
+}
+let p = Point { x = 4, y = 7 }
+let result = {
+    let Point { x, y } = p
+    x * 100 + y
+}
+let swapped = {
+    let Point { y, x } = p
+    x * 100 + y
+}
+// x = 4 and y = 7 in BOTH blocks, so both scalars are 4*100 + 7 = 407.
+// Under a positional rule the second block would bind y = 4 and x = 7, and
+// `swapped` would come out 7*100 + 4 = 704 instead.
+// EXPECT: result = 407
+// EXPECT: swapped = 407

--- a/rewrite/blade-compiler/tests/corpus/bracketed/002_bracketed_comparison.blade
+++ b/rewrite/blade-compiler/tests/corpus/bracketed/002_bracketed_comparison.blade
@@ -5,3 +5,12 @@ let B = [3, 3, 3]
 let less_than = A [<] B
 let equal = A [==] B
 let greater_eq = A [>=] B
+// Each result is the 5x3 outer product A(i) <op> B(j). B is constant 3, so
+// every row is uniform. Rank-2 arrays print FLAT in row-major order
+// (genPrintArrayFlat), so each pin is 15 values -- three per row of A.
+// A = 1,2,3,4,5 vs 3: 1<3 and 2<3 hold, 3<3 / 4<3 / 5<3 do not
+// EXPECT: less_than = [true, true, true, true, true, true, false, false, false, false, false, false, false, false, false]
+// only A(2) = 3 equals 3
+// EXPECT: equal = [false, false, false, false, false, false, true, true, true, false, false, false, false, false, false]
+// 1 and 2 are not >= 3; 3, 4, 5 are
+// EXPECT: greater_eq = [false, false, false, false, false, false, true, true, true, true, true, true, true, true, true]

--- a/rewrite/blade-compiler/tests/corpus/bracketed/003_bracketed_logical.blade
+++ b/rewrite/blade-compiler/tests/corpus/bracketed/003_bracketed_logical.blade
@@ -4,3 +4,10 @@ let P = [true, false, true]
 let Q = [true, true, false]
 let and_result = P [&&] Q
 let or_result = P [||] Q
+// Each result is the 3x3 outer product P(i) <op> Q(j). Rank-2 arrays print
+// FLAT in row-major order (genPrintArrayFlat), so each pin is 9 values --
+// three per row of P.  P = T,F,T   Q = T,T,F
+// and: P(0)=T -> [T,T,F]; P(1)=F -> [F,F,F]; P(2)=T -> [T,T,F]
+// EXPECT: and_result = [true, true, false, false, false, false, true, true, false]
+// or:  P(0)=T -> [T,T,T]; P(1)=F -> [T,T,F]; P(2)=T -> [T,T,T]
+// EXPECT: or_result = [true, true, true, true, true, false, true, true, true]

--- a/rewrite/blade-compiler/tests/corpus/bracketed/010_named_infix.blade
+++ b/rewrite/blade-compiler/tests/corpus/bracketed/010_named_infix.blade
@@ -12,3 +12,6 @@ let c = a + b
 
 // The :name: syntax works at parse level but full test 
 // needs lambda-in-variable calling support (future work)
+// EXPECT: a = 3.0
+// EXPECT: b = 4.0
+// EXPECT: c = 7.0

--- a/rewrite/blade-compiler/tests/corpus/functions/005_non_scalar_kernel.blade
+++ b/rewrite/blade-compiler/tests/corpus/functions/005_non_scalar_kernel.blade
@@ -2,3 +2,5 @@
 // Kernel that operates on 1D slices (irank = 1 for each input)
 let matrix = [[1.0, 2.0], [3.0, 4.0]]
 let O = object_for(lambda(row: Array<Float64 like Idx<2>>) -> row)
+// rank-2 literal prints flat, row-major
+// EXPECT: matrix = [1, 2, 3, 4]

--- a/rewrite/blade-compiler/tests/corpus/index-types/025_ragged_multi_array_rejects.blade
+++ b/rewrite/blade-compiler/tests/corpus/index-types/025_ragged_multi_array_rejects.blade
@@ -7,7 +7,10 @@
 // mixing ragged with dense) is gated rather than silently miscompiled --
 // the standard loop nest knows nothing about per-row lengths. Co-iteration
 // semantics for ragged operands are a rewrite-spec question.
+// REJECT-AT: codegen
 let r = [[1.0, 2.0], [3.0]]
 let d = [10.0, 20.0]
 let x = method_for(r, d) <@> lambda(g: Array<Float64 like RaggedIdx<_>>, y) -> reduce(g, (+)) + y |> compute
-// EXPECT: typecheck failure — ragged operands support only the single-array peel forms.
+// This program TYPE-CHECKS and LOWERS: the gate is the codegen `#error` guard
+// emitted for multi-array method_for over a ragged operand, which g++ then
+// hits. Hence REJECT-AT: codegen, not a typecheck failure.

--- a/rewrite/blade-compiler/tests/corpus/inference-probes/001_inference_unannotated_extents.blade
+++ b/rewrite/blade-compiler/tests/corpus/inference-probes/001_inference_unannotated_extents.blade
@@ -42,8 +42,10 @@
 //      pass criterion.
 // ============================================================================
 // Probe A: extents() on an unannotated kernel param.
-// Expected to fail at typecheck with "extents requires array" or similar
-// — same pattern reduce had before the recent fix.
+// Originally expected to fail at typecheck with "extents requires array" —
+// same pattern reduce had before the recent fix. It now infers, so the
+// probe documents working behavior: extents(g) is each row's length.
 let r = [[1.0, 2.0, 3.0], [4.0, 5.0], [6.0]]
 let sizes = method_for(r) <@> lambda(g) -> extents(g) |> compute
-// If this ever passes: EXPECT: sizes = [3, 2, 1]
+// Row lengths of the ragged literal: 3, 2, 1
+// EXPECT: sizes = [3, 2, 1]

--- a/rewrite/blade-compiler/tests/corpus/inference-probes/002_inference_unannotated_mask.blade
+++ b/rewrite/blade-compiler/tests/corpus/inference-probes/002_inference_unannotated_mask.blade
@@ -6,4 +6,4 @@
 let r = [[1.0, 2.0, 3.0], [4.0, 5.0], [6.0]]
 let sizes = method_for(r) <@> lambda(g) -> extents(mask(g, lambda(x) -> x > 2.0)) |> compute
 // Row lengths: 3, 2, 1
-// If this ever passes: EXPECT: sizes = [3, 2, 1]
+// EXPECT: sizes = [3, 2, 1]

--- a/rewrite/blade-compiler/tests/corpus/inference-probes/003_inference_unannotated_sort.blade
+++ b/rewrite/blade-compiler/tests/corpus/inference-probes/003_inference_unannotated_sort.blade
@@ -1,9 +1,10 @@
 // TEST: Inference: Unannotated Sort
 // Probe C: sort() on an unannotated kernel param. Reduced to first-element
 // for a concrete check.
-// Expected to fail at typecheck — sort inspects the array arg's type.
+// Originally expected to fail at typecheck (sort inspects the array arg's
+// type); it now infers, so the probe documents working behavior.
 let r = [[3.0, 1.0, 2.0], [5.0, 4.0], [6.0]]
 let mins = method_for(r) <@> lambda(g) -> reduce(sort(g, lambda(x) -> x), (+)) |> compute
 // Sort each row ascending, sum (sort doesn't change sum, just order)
 // Sums: 6, 9, 6
-// If this ever passes: EXPECT: mins = [6, 9, 6]
+// EXPECT: mins = [6, 9, 6]

--- a/rewrite/blade-compiler/tests/corpus/inference-probes/006_inference_annotated_extents.blade
+++ b/rewrite/blade-compiler/tests/corpus/inference-probes/006_inference_annotated_extents.blade
@@ -3,4 +3,5 @@
 // If it doesn't, extents has more issues than the Gap-1 pattern alone.
 let r = [[1.0, 2.0, 3.0], [4.0, 5.0], [6.0]]
 let sizes = method_for(r) <@> lambda(g: Array<Float64 like RaggedIdx<_>>) -> extents(g) |> compute
-// If this passes: EXPECT: sizes = [3, 2, 1]
+// Row lengths of the ragged literal: 3, 2, 1
+// EXPECT: sizes = [3, 2, 1]

--- a/rewrite/blade-compiler/tests/corpus/loops/001_method_for.blade
+++ b/rewrite/blade-compiler/tests/corpus/loops/001_method_for.blade
@@ -1,3 +1,5 @@
 // TEST: Method For
 let A = [1.0, 2.0, 3.0]
 let L = method_for(A, A)
+// L is deferred (no |> compute), so only the input array prints
+// EXPECT: A = [1, 2, 3]

--- a/rewrite/blade-compiler/tests/corpus/loops/005_object_for_with_arrays.blade
+++ b/rewrite/blade-compiler/tests/corpus/loops/005_object_for_with_arrays.blade
@@ -3,3 +3,6 @@ let kernel = lambda(a, b) -> a * b + 1.0
 let O = object_for(kernel)
 let A = [1.0, 2.0, 3.0]
 let B = [4.0, 5.0, 6.0]
+// O is a loop object (nothing materialized); the input arrays print
+// EXPECT: A = [1, 2, 3]
+// EXPECT: B = [4, 5, 6]

--- a/rewrite/blade-compiler/tests/corpus/loops/006_combinators.blade
+++ b/rewrite/blade-compiler/tests/corpus/loops/006_combinators.blade
@@ -6,3 +6,6 @@ let L2 = method_for(B, B)
 let f = lambda(x, y) -> x + y
 // Parallel composition
 let parallel = (L1 <@> f) <&> (L2 <@> f)
+// parallel is deferred (no |> compute); the input arrays print
+// EXPECT: A = [1, 2]
+// EXPECT: B = [3, 4]

--- a/rewrite/blade-compiler/tests/corpus/loops/065_fusion_mismatched_extents.blade
+++ b/rewrite/blade-compiler/tests/corpus/loops/065_fusion_mismatched_extents.blade
@@ -3,6 +3,7 @@
 // cannot share a nest, and the compiler must say so loudly (#error with a
 // steering diagnostic pointing at <&>) rather than emit a nest that reads
 // past C's extent or silently fall back to independent loops.
+// REJECT-AT: codegen
 let A = [1.0, 2.0, 3.0]
 let C = [10.0, 20.0]
 let f = lambda(x) -> x + 1.0

--- a/rewrite/blade-compiler/tests/corpus/modules/001_module_declaration.blade
+++ b/rewrite/blade-compiler/tests/corpus/modules/001_module_declaration.blade
@@ -3,3 +3,4 @@ module Math.Geometry
 
 let pi = 3.14159
 function circleArea(r: Float64) -> Float64 = pi * r * r
+// EXPECT: pi = 3.14159

--- a/rewrite/blade-compiler/tests/corpus/reynolds/014_fusion_mixed_backend_bang_rejects.blade
+++ b/rewrite/blade-compiler/tests/corpus/reynolds/014_fusion_mixed_backend_bang_rejects.blade
@@ -2,7 +2,10 @@
 // <&!> requires identical backends at the shared level. mean is serial (no
 // clause) and cov requests omp — a mismatch. Mandatory fusion cannot silently
 // pick one, so the compiler rejects loudly with steering to <&> (which would
-// let the serial leaf defer to the omp sibling instead).
+// let the serial leaf defer to the omp sibling instead). The mismatch is
+// caught in codegen: lowering succeeds and the emitted C++ carries an #error
+// naming the mixed serial/omp leaves, so the C++ compile is what fails.
+// REJECT-AT: codegen
 let A = [1.0, 2.0, 3.0]
 let mean = lambda(x) -> x
 let cov = lambda(x, y) where omp(x: 1) -> x * y

--- a/rewrite/blade-compiler/tests/corpus/sql-group-by/020_groupby_elementwise_rejects.blade
+++ b/rewrite/blade-compiler/tests/corpus/sql-group-by/020_groupby_elementwise_rejects.blade
@@ -7,9 +7,12 @@
 // the wrapper metadata the shape-preserving map shares, and group-shaped
 // outputs have no downstream consumers yet). Mapping BEFORE grouping is
 // semantically equivalent and supported.
+// REJECT-AT: codegen
 let region = [0, 1, 0]
 let temps = [10.0, 20.0, 30.0]
 let gk = group_keys(region)
 let grouped = group_by(temps, gk)
 let d = method_for(grouped) <@> lambda(e) -> e * 2.0 |> compute
-// EXPECT: typecheck failure — elementwise map over a group_by result is gated; map before grouping.
+// EXPECT: codegen rejection — this type-checks and lowers; the gate is an
+// #error emitted into the generated C++ ("elementwise map over a group_by
+// result is not yet supported"), so g++ is what fails. Map before grouping.

--- a/rewrite/blade-compiler/tests/corpus/static/008_static_in_type_extent.blade
+++ b/rewrite/blade-compiler/tests/corpus/static/008_static_in_type_extent.blade
@@ -5,3 +5,6 @@ let A = [1.0, 2.0, 3.0, 4.0, 5.0]
 let L = method_for(A, A)
 let f = lambda(x, y) where comm(x, y) -> x * y
 let result = L <@> f
+// result is deferred (no |> compute); the static extent and input print
+// EXPECT: n = 5
+// EXPECT: A = [1, 2, 3, 4, 5]

--- a/rewrite/blade-compiler/tests/corpus/static/026_static_cons_destructure.blade
+++ b/rewrite/blade-compiler/tests/corpus/static/026_static_cons_destructure.blade
@@ -1,0 +1,20 @@
+// TEST: Static Cons Destructure
+// `let static head :: tail = (...)`. checkDecl's DeclStatic arm used to handle
+// PatTuple only and hardcode DSPositional, so cons leaves under `let static`
+// were never bound at all. Semantics match the plain top-level form
+// (basic/010_cons_destructure): head is element 0, tail is the REMAINDER — the
+// 2-tuple (20, 30), not element 1.
+//
+// Unlike `let static (m, n) = ...` (013), these leaves are NOT compile-time
+// constants: StaticEval.bindPattern has no PatCons case, so nothing lands in
+// env.StaticValues for them and Lowering's TDeclStatic path takes its
+// projection fallback, driven by the DSConsRest tag.
+//
+// A tuple-typed binding prints nothing (std::tuple has no operator<<), so tail
+// is re-destructured into scalars to observe it.
+let static head :: tail = (10, 20, 30)
+let h = head
+let (t0, t1) = tail
+// EXPECT: h = 10
+// EXPECT: t0 = 20
+// EXPECT: t1 = 30

--- a/rewrite/blade-compiler/tests/corpus/static/027_static_struct_destructure.blade
+++ b/rewrite/blade-compiler/tests/corpus/static/027_static_struct_destructure.blade
@@ -1,0 +1,29 @@
+// TEST: Static Struct Destructure
+// `let static Sample { count, scale } = ...`. checkDecl's DeclStatic arm used to
+// handle PatTuple and PatCons only, so a struct pattern under `let static`
+// recorded no sub-bindings and both field names surfaced as UnboundVariable.
+//
+// Note the contrast with the cons form (026): StaticEval.bindPattern DOES have a
+// PatStruct case, so each leaf had ALREADY been folded to a compile-time value
+// and sat in env.StaticValues with nothing to attach it to. The sub-binding the
+// checker now records is what gives that folded value its name, IRId and type,
+// and Lowering's TDeclStatic path then prefers the constant over a field
+// projection.
+//
+// Field types come from the struct's DECLARED field list (structFieldTypesOf,
+// shared with the DeclLet arm), so the mixed pair below has to survive intact:
+// `scale` is a Float64 leaf carrying 2.5, not an Int leaf truncating it to 2.
+//
+// A struct-typed binding prints nothing (`IRTNamed _ -> []` in
+// genPrintStatements), and static leaves are pinned through plain lets by
+// convention (013, 024), so each leaf is re-bound before being observed.
+struct Sample {
+    count: Int,
+    scale: Float64
+}
+let static Sample { count, scale } = Sample { count = 6, scale = 2.5 }
+let n = count
+let s = scale
+// count = 6 and scale = 2.5, read out of the folded struct by field name.
+// EXPECT: n = 6
+// EXPECT: s = 2.5

--- a/rewrite/blade-compiler/tests/corpus/static/028_two_destructured_statics.blade
+++ b/rewrite/blade-compiler/tests/corpus/static/028_two_destructured_statics.blade
@@ -1,0 +1,36 @@
+// TEST: Two Destructured Statics In One Module
+// REGRESSION for a latent varId collision, and the reason this file exists at
+// all: no corpus module had TWO destructured statics, so the defect could not
+// show up anywhere.
+//
+// checkModule's pre-pass registers every `let static` under a key taken from its
+// pattern — the real name for `let static x`, the synthetic "_" for ANY
+// destructuring pattern — and checkDecl's DeclStatic arm adopted whatever
+// `lookupVar "_"` returned. With ONE destructured static per module that read
+// back its own entry and happened to work. With two, the second adopted the
+// FIRST one's varId: both module bindings then shared a single IRId (one C++
+// `__tup_N`, emitted twice) and the `unify` that exists to resolve forward
+// references welded their two unrelated types together. DeclStatic now takes a
+// fresh id whenever the pattern destructures, because the pre-pass entry for "_"
+// never carried any forward reference worth adopting — it registers none of the
+// pattern's real leaf names.
+//
+// The two statics below are deliberately different SHAPES and different TYPES
+// (a 2-tuple positional split and a 3-tuple cons split), so a shared id or a
+// shared type cannot accidentally still produce the right answers.
+//
+// Leaf semantics are unchanged from the single-static forms: 013 for the tuple
+// rule, 026 for the cons rule (head is element 0, tail is the REMAINDER, not
+// element 1). A tuple-typed binding prints nothing, so `tail` is re-destructured
+// into scalars to be observed.
+let static (a, b) = (1, 2)
+let static head :: tail = (10, 20, 30)
+let s1 = a * 10 + b
+let h = head
+let (t0, t1) = tail
+// a = 1 and b = 2, so s1 = 1*10 + 2 = 12.
+// head = 10 and tail = (20, 30), so t0 = 20 and t1 = 30.
+// EXPECT: s1 = 12
+// EXPECT: h = 10
+// EXPECT: t0 = 20
+// EXPECT: t1 = 30

--- a/rewrite/blade-compiler/tests/corpus/zero-combinators/005_zero_kernel_symmetric.blade
+++ b/rewrite/blade-compiler/tests/corpus/zero-combinators/005_zero_kernel_symmetric.blade
@@ -1,6 +1,13 @@
 // TEST: Zero Kernel Symmetric
-// method_for(A, A) <@> zero with symmetric arrays
+// method_for(A, A) <@> zero over the same array twice.
+// The zero kernel is SYNTHESIZED by TypeCheck (TExprMethodFor/TExprZero) with
+// CommGroups = [], so no comm licence reaches computeAxisGroups: the two
+// levels stay in distinct axis groups and the nest is the FULL 3x3 product,
+// not the triangular 6-element packing a `where comm(x, y)` kernel would get
+// (contrast loops/003, which pins 9 values, against reynolds/004's 6).
+// Every element is the Float64 zero literal.
+// EXPECT is FLAT: a rank-2 result prints flattened row-major.
 let A = [1.0, 2.0, 3.0]
 let L = method_for(A, A)
 let result = L <@> zero |> compute
-// EXPECT: result [symmetric]
+// EXPECT: result = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]

--- a/rewrite/blade-compiler/tests/corpus/zero-combinators/006_zero_objectfor.blade
+++ b/rewrite/blade-compiler/tests/corpus/zero-combinators/006_zero_objectfor.blade
@@ -1,5 +1,10 @@
 // TEST: Zero ObjectFor
-// object_for(zero) <@> arrays
+// object_for(zero) <@> arrays — the object_for spelling of 005.
+// The synthesized zero kernel carries CommGroups = [], so the two operands
+// are not comm-partnered and the nest is the FULL 3x3 product (same shape
+// loops/062's `object_for(k2) <@> (A, A)` pins with 9 values), every element
+// the Float64 zero literal.
+// EXPECT is FLAT: a rank-2 result prints flattened row-major.
 let A = [1.0, 2.0, 3.0]
 let result = object_for(zero) <@> (A, A) |> compute
-// EXPECT: result [symmetric]
+// EXPECT: result = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]


### PR DESCRIPTION
The suite reported "TOTAL: 1202 passed, 0 failed" while a large fraction of it was never actually checked. Fixes the accounting, then the compiler bugs that accounting had been hiding.

Harness accuracy:
- Reject-probes were credited as passing if they failed for ANY reason. 161 of 921 tests are probes, so a broken toolchain produced a green suite: an accidental run with no working g++ reported "All 150 passed" while "Compiled: 0 / 921". Probes now pin WHERE they must be rejected
  via a new `// REJECT-AT: lower|codegen` corpus directive (absent =>
  lower), and a codegen rejection is only credited when the generated source actually contains an emitted #error guard.
- The per-test line and the block roll-up decided verdicts separately and disagreed on skips. Both now derive from a single `classify`.
- 2D EXPECT pins were parsed then discarded (`-> None`, "skip 2D array checking"). Now compared for real.
- Unparseable EXPECT lines were silently dropped, which made the value gate vacuous and let the test pass on "compiled and exited 0". They now fail the test. Prose lines on reject-probes stay exempt.
- parseFloatList coerced unparseable elements to 0.0. Now strict: a bad element fails the whole pin.
- Bool arrays were structurally unpinnable (Double.Parse vs boolalpha). Added `[true, false]` pin support.
- Normalize, Unify and Validate Arrow returned BlockResults that the full suite never collected; InterpDiff and DiffOracle added as opt-in.
- The Test Summary reported "146 failed" for a run whose grand total said "0 failed", with nothing reconciling them. It now reports probe populations and a Verdict line that is literally the block result.

Compiler bugs (all previously green):
- `let head :: tail = t` bound `tail` to the second ELEMENT instead of the remainder, and typed both leaves `double` on an int64 tuple.
- Bracketed outer-product comparison/logical ops (`[<]`, `[==]`, `[&&]`, …) were typed as scalar Bool, so the print path took the scalar branch and emitted a POINTER ADDRESS via Array's implicit conversion. The rank-2 loop codegen was already correct.
- Destructuring bound nothing in several binders: PatStruct in block scope and under `let static`, cons in block/static/expression position, and flat tuple matches in expression position. Names surfaced as UnboundVariable, or worse, lowered to a dangling IRId.
- Two destructured `let static`s in one module shared a varId (both keyed as "_" by a pre-pass), unifying their types and emitting the same C++ variable twice.
- inferArithType: removed a duplicated unreachable match arm; outer-product results no longer inherit the left operand's Identity/IsVirtual or stale index-type ids.

Value Check rose 726 -> 749 purely from assertions that already existed in the corpus and had never executed. 15 deliberate mutations (2D pins, bool pins, malformed pins, mis-pinned reject stages, wrong destructure values, a reject-probe made legal) were each verified to turn the suite red.

Committed as one change because every intermediate split I could stage would have been an unverified state; this exact tree was built and run.